### PR TITLE
add access_token for github api, use NVCHECKER_GITHUB_TOKEN env var

### DIFF
--- a/nvchecker/source/github.py
+++ b/nvchecker/source/github.py
@@ -1,7 +1,8 @@
+import os
 import json
 from functools import partial
 
-from tornado.httpclient import AsyncHTTPClient
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
 GITHUB_URL = 'https://api.github.com/repos/%s/commits?sha=%s'
 
@@ -9,7 +10,11 @@ def get_version(name, conf, callback):
   repo = conf.get('github')
   br = conf.get('branch', 'master')
   url = GITHUB_URL % (repo, br)
-  AsyncHTTPClient().fetch(url, user_agent='lilydjwg/nvchecker',
+  headers = {}
+  if 'NVCHECKER_GITHUB_TOKEN' in os.environ:
+      headers = {'Authorization': 'token %s' % os.environ['NVCHECKER_GITHUB_TOKEN']}
+  request = HTTPRequest(url, headers=headers)
+  AsyncHTTPClient().fetch(request, user_agent='lilydjwg/nvchecker',
                           callback=partial(_github_done, name, callback))
 
 def _github_done(name, callback, res):


### PR DESCRIPTION
Github now have a limit of 60 access/hour for unauthorized api access. Using access token will leverage this limit to 5000 access/hour.
Set NVCHECKER_GITHUB_TOKEN as a OAuth access token (personal access token is OK) to set access token.