### PR TITLE
escape aurname in url

### DIFF
--- a/nvchecker/source/aur.py
+++ b/nvchecker/source/aur.py
@@ -3,6 +3,7 @@ import json
 import logging
 
 from tornado.httpclient import AsyncHTTPClient
+from tornado.escape import url_escape
 
 AUR_URL = 'https://aur.archlinux.org/rpc.php?type=info&arg='
 
@@ -10,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 def get_version(name, conf, callback):
   aurname = conf.get('aur') or name
-  url = AUR_URL + aurname
+  url = AUR_URL + url_escape(aurname)
   AsyncHTTPClient().fetch(url, partial(_aur_done, name, callback))
 
 def _aur_done(name, callback, res):


### PR DESCRIPTION
aurname would contain some special char that needs to escape.
An example will be "libstdc++-doc" -> "libstdc%2B%2B-doc"