### PR TITLE
handle github repo redirects using preview api

### DIFF
--- a/nvchecker/source/github.py
+++ b/nvchecker/source/github.py
@@ -12,7 +12,10 @@ def get_version(name, conf, callback):
   url = GITHUB_URL % (repo, br)
   headers = {}
   if 'NVCHECKER_GITHUB_TOKEN' in os.environ:
-      headers = {'Authorization': 'token %s' % os.environ['NVCHECKER_GITHUB_TOKEN']}
+      headers = {
+          'Authorization': 'token %s' % os.environ['NVCHECKER_GITHUB_TOKEN'],
+          'Accept': "application/vnd.github.quicksilver-preview+json"
+      }
   request = HTTPRequest(url, headers=headers)
   AsyncHTTPClient().fetch(request, user_agent='lilydjwg/nvchecker',
                           callback=partial(_github_done, name, callback))

--- a/nvchecker/source/github.py
+++ b/nvchecker/source/github.py
@@ -10,12 +10,9 @@ def get_version(name, conf, callback):
   repo = conf.get('github')
   br = conf.get('branch', 'master')
   url = GITHUB_URL % (repo, br)
-  headers = {}
+  headers = {'Accept': "application/vnd.github.quicksilver-preview+json"}
   if 'NVCHECKER_GITHUB_TOKEN' in os.environ:
-      headers = {
-          'Authorization': 'token %s' % os.environ['NVCHECKER_GITHUB_TOKEN'],
-          'Accept': "application/vnd.github.quicksilver-preview+json"
-      }
+      headers['Authorization'] = 'token %s' % os.environ['NVCHECKER_GITHUB_TOKEN']
   request = HTTPRequest(url, headers=headers)
   AsyncHTTPClient().fetch(request, user_agent='lilydjwg/nvchecker',
                           callback=partial(_github_done, name, callback))


### PR DESCRIPTION
Checking a renamed github repo from github API will receive a HTTP 404 currently. However cloning the renamed repo will continue to success using the old repo url because of the graceful redirection by github. Therefore the packager will not notice the difference while nvchecker will.

This patch utilize the newly introduced [preview repository redirects](https://developer.github.com/changes/2015-04-17-preview-repository-redirects/) feature to allow renamed repo redirection when accessing from API.

This feature is currently in preview state and will be finalized in future.

An example of which will benefit from this would be the `archlinuxcn/vim-nim-git` package. It clones https://github.com/zah/nimrod.vim which will be redirected to https://github.com/zah/nim.vim