### PR TITLE
fixed no user-agent error for github.py

### DIFF
--- a/nvchecker/source/github.py
+++ b/nvchecker/source/github.py
@@ -13,8 +13,8 @@ def get_version(name, conf, callback):
   headers = {'Accept': "application/vnd.github.quicksilver-preview+json"}
   if 'NVCHECKER_GITHUB_TOKEN' in os.environ:
       headers['Authorization'] = 'token %s' % os.environ['NVCHECKER_GITHUB_TOKEN']
-  request = HTTPRequest(url, headers=headers)
-  AsyncHTTPClient().fetch(request, user_agent='lilydjwg/nvchecker',
+  request = HTTPRequest(url, headers=headers, user_agent='lilydjwg/nvchecker')
+  AsyncHTTPClient().fetch(request,
                           callback=partial(_github_done, name, callback))
 
 def _github_done(name, callback, res):


### PR DESCRIPTION
The original code cause error as following.
```
[E 06-28 00:10:31.770 ioloop:612] Exception in callback functools.partial(<function wrap.
<locals>.wrapped at 0x7fe6e47b4488>, 
HTTPResponse(
_body=b'Request forbidden by administrative rules. Please make sure your request has a User-Agent header (http://developer.github.com/v3/#user-agent-required). Check https://developer.github.com for other possible causes.\n',
buffer=<_io.BytesIO object at 0x7fe6e42741c8>,
code=403,
effective_url='https://api.github.com/repos/kikyous/xfdown/commits?sha=beta',
error=HTTPError('HTTP 403: Forbidden',),
headers={'Content-Type': 'text/html', 'Connection': 'close', 'Cache-Control': 'no-cache'},
reason='Forbidden',
request=<tornado.httpclient.HTTPRequest object at 0x7fe6e47ce898>,
request_time=1.1009521484375,time_info={}))
    Traceback (most recent call last):
      File "/usr/lib/python3.4/site-packages/tornado/ioloop.py", line 592, in _run_callback
        ret = callback()
      File "/usr/lib/python3.4/site-packages/tornado/stack_context.py", line 343, in wrapped
        raise_exc_info(exc)
      File "<string>", line 3, in raise_exc_info
      File "/usr/lib/python3.4/site-packages/tornado/stack_context.py", line 355, in _handle_exception
        if tail.exit(*exc):
      File "/usr/lib/python3.4/site-packages/tornado/stack_context.py", line 186, in exit
        return self.exception_handler(type, value, traceback)
      File "/usr/lib/python3.4/site-packages/nvchecker/core.py", line 98, in _handle_exception
        raise value.with_traceback(traceback)
      File "/usr/lib/python3.4/site-packages/tornado/stack_context.py", line 314, in wrapped
        ret = fn(*args, **kwargs)
      File "/usr/lib/python3.4/site-packages/nvchecker/source/github.py", line 21, in _github_done
        data = json.loads(res.body.decode('utf-8'))
      File "/usr/lib/python3.4/json/__init__.py", line 318, in loads
        return _default_decoder.decode(s)
      File "/usr/lib/python3.4/json/decoder.py", line 343, in decode
        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
      File "/usr/lib/python3.4/json/decoder.py", line 361, in raw_decode
        raise ValueError(errmsg("Expecting value", s, err.value)) from None
    ValueError: Expecting value: line 1 column 1 (char 0)
```