### PR TITLE
add github tags support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,15 @@ branch
 
 An environment variable ``NVCHECKER_GITHUB_TOKEN`` can be set to a GitHub OAuth token in order to request more frequently than anonymously.
 
+Check GitHub Tags
+------------
+Check `GitHub <https://github.com/>`_ for updates of tags.
+
+github_tags
+  The github repository, with author, e.g. ``u8sand/baka-mplayer``.
+
+An environment variable ``NVCHECKER_GITHUB_TOKEN`` can be set to a GitHub OAuth token in order to request more frequently than anonymously.
+
 Check BitBucket
 ---------------
 Check `BitBucket <https://bitbucket.org/>`_ for updates. The version returned is in date format ``%Y%m%d``, e.g. ``20130701``.

--- a/nvchecker/get_version.py
+++ b/nvchecker/get_version.py
@@ -3,7 +3,7 @@ from importlib import import_module
 
 logger = logging.getLogger(__name__)
 handler_precedence = (
-  'github', 'gitcafe', 'aur', 'pypi', 'archpkg', 'gems', 'pacman',
+  'github','github_tags', 'gitcafe', 'aur', 'pypi', 'archpkg', 'gems', 'pacman',
   'cmd', 'bitbucket', 'gcode_hg', 'gcode_svn', 'regex', 'manual', 'vcs',
 )
 

--- a/nvchecker/source/github_tags.py
+++ b/nvchecker/source/github_tags.py
@@ -1,0 +1,22 @@
+import os
+import json
+from functools import partial
+
+from tornado.httpclient import AsyncHTTPClient
+
+GITHUB_TAGS_URL = 'https://api.github.com/repos/%s/tags'
+
+def get_version(name, conf, callback):
+    repo = conf.get('github_tags')
+    url = GITHUB_TAGS_URL % (repo)
+    headers = {'Accept': "application/vnd.github.quicksilver-preview+json"}
+    if 'NVCHECKER_GITHUB_TOKEN' in os.environ:
+        headers['Authorization'] = 'token %s' % os.environ['NVCHECKER_GITHUB_TOKEN']
+        request = HTTPRequest(url, headers=headers, user_agent='lilydjwg/nvchecker')
+        AsyncHTTPClient().fetch(request,
+                callback=partial(_github_tags_done, name, callback))
+
+def _github_tags_done(name, callback, res):
+    data = json.loads(res.body.decode('utf-8'))
+    version = data[0]['name'].strip('v')
+    callback(name, version)

--- a/nvchecker/source/github_tags.py
+++ b/nvchecker/source/github_tags.py
@@ -4,19 +4,19 @@ from functools import partial
 
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
-GITHUB_TAGS_URL = 'https://api.github.com/repos/%s/tags'
+GITHUB_URL = 'https://api.github.com/repos/%s/tags'
 
 def get_version(name, conf, callback):
-    repo = conf.get('github_tags')
-    url = GITHUB_TAGS_URL % (repo)
-    headers = {'Accept': "application/vnd.github.quicksilver-preview+json"}
-    if 'NVCHECKER_GITHUB_TOKEN' in os.environ:
-        headers['Authorization'] = 'token %s' % os.environ['NVCHECKER_GITHUB_TOKEN']
-        request = HTTPRequest(url, headers=headers, user_agent='lilydjwg/nvchecker')
-        AsyncHTTPClient().fetch(request,
-                		callback=partial(_github_tags_done, name, callback))
+  repo = conf.get('github_tags')
+  url = GITHUB_URL % (repo)
+  headers = {'Accept': "application/vnd.github.quicksilver-preview+json"}
+  if 'NVCHECKER_GITHUB_TOKEN' in os.environ:
+      headers['Authorization'] = 'token %s' % os.environ['NVCHECKER_GITHUB_TOKEN']
+  request = HTTPRequest(url, headers=headers, user_agent='lilydjwg/nvchecker')
+  AsyncHTTPClient().fetch(request,
+                          callback=partial(_github_tags_done, name, callback))
 
 def _github_tags_done(name, callback, res):
-    data = json.loads(res.body.decode('utf-8'))
-    version = data[0]['name'].strip('v')
-    callback(name, version)
+  data = json.loads(res.body.decode('utf-8'))
+  version = data[0]['name'].strip('v')
+  callback(name, version)

--- a/nvchecker/source/github_tags.py
+++ b/nvchecker/source/github_tags.py
@@ -14,7 +14,7 @@ def get_version(name, conf, callback):
         headers['Authorization'] = 'token %s' % os.environ['NVCHECKER_GITHUB_TOKEN']
         request = HTTPRequest(url, headers=headers, user_agent='lilydjwg/nvchecker')
         AsyncHTTPClient().fetch(request,
-                callback=partial(_github_tags_done, name, callback))
+                		callback=partial(_github_tags_done, name, callback))
 
 def _github_tags_done(name, callback, res):
     data = json.loads(res.body.decode('utf-8'))

--- a/nvchecker/source/github_tags.py
+++ b/nvchecker/source/github_tags.py
@@ -2,7 +2,7 @@ import os
 import json
 from functools import partial
 
-from tornado.httpclient import AsyncHTTPClient
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
 GITHUB_TAGS_URL = 'https://api.github.com/repos/%s/tags'
 


### PR DESCRIPTION
it still has an issue:
repos like shadowsocks/libqtshadowsocks return the rc version in https://api.github.com/repositories/26507885/tags, which is not the latest release