### PR TITLE
Add ignored_tags support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
   - "3.4"
   - "3.5"
-install: pip install pytest-runner
+install: pip install -U pytest pytest-runner
 script: python setup.py ptr
 env:
   global:

--- a/README.rst
+++ b/README.rst
@@ -174,6 +174,11 @@ use_max_tag
   this option includes both annotated tags and lightweight ones, and return the biggest one
   sorted by ``pkg_resources.parse_version``.
 
+ignored_tags
+  Ignore certain tags while sorting. Tags are separate by whitespaces. This option must be
+  used together with use_max_tag. This can be useful to avoid some known badly versioned
+  tags, so the newer tags won't be "overridden" by the old broken ones.
+
 An environment variable ``NVCHECKER_GITHUB_TOKEN`` can be set to a GitHub OAuth token in order to request more frequently than anonymously.
 
 Check BitBucket
@@ -189,6 +194,11 @@ branch
 use_max_tag
   Set this to ``true`` to check for the max tag on BitBucket. Will return the biggest one
   sorted by ``pkg_resources.parse_version``.
+
+ignored_tags
+  Ignore certain tags while sorting. Tags are separate by whitespaces. This option must be
+  used together with use_max_tag. This can be useful to avoid some known badly versioned
+  tags, so the newer tags won't be "overridden" by the old broken ones.
 
 Check GitCafe
 -------------
@@ -215,6 +225,11 @@ branch
 use_max_tag
   Set this to ``true`` to check for the max tag on BitBucket. Will return the biggest one
   sorted by ``pkg_resources.parse_version``.
+
+ignored_tags
+  Ignore certain tags while sorting. Tags are separate by whitespaces. This option must be
+  used together with use_max_tag. This can be useful to avoid some known badly versioned
+  tags, so the newer tags won't be "overridden" by the old broken ones.
 
 host
   Hostname for self-hosted GitLab instance.

--- a/nvchecker/source/bitbucket.py
+++ b/nvchecker/source/bitbucket.py
@@ -13,18 +13,19 @@ def get_version(name, conf, callback):
   repo = conf.get('bitbucket')
   br = conf.get('branch', '')
   use_max_tag = conf.getboolean('use_max_tag', False)
+  ignored_tags = conf.get("ignored_tags", "").split()
   if use_max_tag:
     url = BITBUCKET_MAX_TAG % repo
   else:
     url = BITBUCKET_URL % (repo, br)
   request = HTTPRequest(url, user_agent='lilydjwg/nvchecker')
   AsyncHTTPClient().fetch(request,
-                          callback=partial(_bitbucket_done, name, use_max_tag, callback))
+                          callback=partial(_bitbucket_done, name, use_max_tag, ignored_tags, callback))
 
-def _bitbucket_done(name, use_max_tag, callback, res):
+def _bitbucket_done(name, use_max_tag, ignored_tags, callback, res):
   data = json.loads(res.body.decode('utf-8'))
   if use_max_tag:
-    data = list(data)
+    data = [tag for tag in data if tag not in ignored_tags]
     data.sort(key=parse_version)
     version = data[-1]
   else:

--- a/tests/test_bitbucket.py
+++ b/tests/test_bitbucket.py
@@ -7,3 +7,6 @@ class BitBucketTest(ExternalVersionTestCase):
 
     def test_bitbucket_max_tag(self):
         self.assertEqual(self.sync_get_version("example", {"bitbucket": "prawee/git-tag", "use_max_tag": 1}), "1.7.0")
+
+    def test_bitbucket_max_tag_with_ignored_tags(self):
+        self.assertEqual(self.sync_get_version("example", {"bitbucket": "prawee/git-tag", "use_max_tag": 1, "ignored_tags": "1.6.0 1.7.0"}), "v1.5")

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -14,3 +14,6 @@ class GitHubTest(ExternalVersionTestCase):
 
     def test_github_max_tag(self):
         self.assertEqual(self.sync_get_version("example", {"github": "harry-sanabria/ReleaseTestRepo", "use_max_tag": 1}), "second_release")
+
+    def test_github_max_tag_with_ignored_tags(self):
+        self.assertEqual(self.sync_get_version("example", {"github": "harry-sanabria/ReleaseTestRepo", "use_max_tag": 1, "ignored_tags": "second_release release3"}), "first_release")

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -14,3 +14,6 @@ class GitLabTest(ExternalVersionTestCase):
 
     def test_gitlab_max_tag(self):
         self.assertEqual(self.sync_get_version("example", {"gitlab": "gitlab-org/gitlab-test", "use_max_tag": 1}), "v1.1.0")
+
+    def test_gitlab_max_tag_with_ignored_tags(self):
+        self.assertEqual(self.sync_get_version("example", {"gitlab": "gitlab-org/gitlab-test", "use_max_tag": 1, "ignored_tags": "v1.1.0"}), "v1.0.0")


### PR DESCRIPTION
Ignore certain tags while sorting. This option must be used together with
use_max_tag. This can be useful to avoid some known badly versioned tags,
so the newer tags won't be "overriden" by the old broken ones.