### PR TITLE
Use proxy settings if set for github and cpan repos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,6 +189,9 @@ sort_version_key
   ``vercmp``. Default value is ``parse_version``. ``parse_version`` use 
   ``pkg_resources.parse_version``. ``vercmp`` use ``pyalpm.vercmp``.
 
+proxy
+  The HTTP proxy to use. The format is ``host:port``, e.g. ``localhost:8087``. This requires `pycurl <http://pycurl.sourceforge.net/>`_.
+
 An environment variable ``NVCHECKER_GITHUB_TOKEN`` can be set to a GitHub OAuth token in order to request more frequently than anonymously.
 
 Check BitBucket
@@ -283,6 +286,9 @@ Check `MetaCPAN <https://metacpan.org/>`_ for updates.
 
 cpan
   The name used on CPAN, e.g. ``YAML``.
+
+proxy
+  The HTTP proxy to use. The format is ``host:port``, e.g. ``localhost:8087``. This requires `pycurl <http://pycurl.sourceforge.net/>`_.
 
 Check Packagist
 ---------------

--- a/nvchecker/source/github.py
+++ b/nvchecker/source/github.py
@@ -4,6 +4,7 @@ from functools import partial
 
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
+from .base import pycurl
 from ..sortversion import sort_version_keys
 
 GITHUB_URL = 'https://api.github.com/repos/%s/commits?sha=%s'
@@ -26,7 +27,15 @@ def get_version(name, conf, callback):
   headers = {'Accept': "application/vnd.github.quicksilver-preview+json"}
   if 'NVCHECKER_GITHUB_TOKEN' in os.environ:
     headers['Authorization'] = 'token %s' % os.environ['NVCHECKER_GITHUB_TOKEN']
-  request = HTTPRequest(url, headers=headers, user_agent='lilydjwg/nvchecker')
+
+  kwargs = {}
+  if conf.get('proxy'):
+    if pycurl:
+      kwargs['proxy_host'] = "".join(conf['proxy'].split(':')[:-1])
+      kwargs['proxy_port'] = int(conf['proxy'].split(':')[-1])
+    else:
+      logger.warn('%s: proxy set but not used because pycurl is unavailable.', name)
+  request = HTTPRequest(url, headers=headers, user_agent='lilydjwg/nvchecker', **kwargs)
   AsyncHTTPClient().fetch(request,
                           callback=partial(_github_done, name, use_latest_release, use_max_tag, ignored_tags, sort_version_key, callback))
 

--- a/nvchecker/source/simple_json.py
+++ b/nvchecker/source/simple_json.py
@@ -3,13 +3,23 @@ from functools import partial
 
 from tornado.httpclient import AsyncHTTPClient
 
+from .base import pycurl
+
 def simple_json(urlpat, confkey, version_from_json):
 
   def get_version(name, conf, callback):
     repo = conf.get(confkey) or name
     url = urlpat % repo
+    kwargs = {}
+    if conf.get('proxy'):
+      if pycurl:
+        kwargs['proxy_host'] = "".join(conf['proxy'].split(':')[:-1])
+        kwargs['proxy_port'] = int(conf['proxy'].split(':')[-1])
+      else:
+        logger.warn('%s: proxy set but not used because pycurl is unavailable.', name)
+
     AsyncHTTPClient().fetch(url, user_agent='lilydjwg/nvchecker',
-                            callback=partial(_json_done, name, callback))
+                            callback=partial(_json_done, name, callback), **kwargs)
 
   def _json_done(name, callback, res):
     data = json.loads(res.body.decode('utf-8'))


### PR DESCRIPTION
works for me with following .ini-file (obfuscated a bit)
```
$ cat config.ini
[__config__]
oldver = old_ver.txt
newver = new_ver.txt

[Memcached]
cpan =  Cache-Memcached
proxy = proxy.example.com:3128

[nvchecker]
github = lilydjwg/nvchecker
proxy = proxy.example.com:3128
```