### PR TITLE
CPAN: Use metacpan fastapi

### DIFF
--- a/nvchecker/source/cpan.py
+++ b/nvchecker/source/cpan.py
@@ -1,7 +1,7 @@
 from .simple_json import simple_json
 
 # Using metacpan
-CPAN_URL = 'https://api.metacpan.org/release/%s'
+CPAN_URL = 'https://fastapi.metacpan.org/release/%s'
 
 def _version_from_json(data):
   return str(data['version'])


### PR DESCRIPTION
All docs in metacpan.org currently point to this new API endpoint. The
old API endpoint returns wrong data for e.g. TermReadKey (latest 2.37 vs
API 2.14), and the new API endpoint doesn't have this issue.