### PR TITLE
Use new pytest-runner command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   # ptr requires Python >= 3.3 but pypy3 reports 3.2
   # - "pypy3"
 install: pip install -U pytest pytest-runner
-script: python setup.py ptr
+script: python setup.py pytest
 env:
   global:
     - ASYNC_TEST_TIMEOUT=20


### PR DESCRIPTION
`ptr` is considered deprecated and will be removed in a future version.