### PR TITLE
Improve error message for non-exist nvtake targets

### DIFF
--- a/nvchecker/tools.py
+++ b/nvchecker/tools.py
@@ -31,7 +31,13 @@ def take():
   newvers = core.read_verfile(s.newver)
 
   for name in args.names:
-    oldvers[name] = newvers[name]
+    try:
+      oldvers[name] = newvers[name]
+    except KeyError:
+      logger.fatal(
+        "%s doesn't exist in 'newver' set.", name
+      )
+      sys.exit(2)
 
   try:
       os.rename(s.oldver, s.oldver + '~')


### PR DESCRIPTION
`nvtake foo` was giving the following error:

```
Traceback (most recent call last):
  File "/usr/bin/nvtake", line 11, in <module>
    load_entry_point('nvchecker==0.5', 'console_scripts', 'nvtake')()
  File "/usr/lib/python3.6/site-packages/nvchecker/tools.py", line 34, in take
    oldvers[name] = newvers[name]
KeyError: 'foo'
```

This is unclear and too verbose. With the change it is now:

```
[C 08-05 02:51:46.767 tools:38] foo doesn't exist in 'newver' set.
```