### PR TITLE
Add support for substitutions of version strings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ prefix
 
 from_pattern, to_pattern
   Both are Python-compatible regular expressions. If ``from_pattern`` is found
-  in the version string, it will be replaced with ``to_pattern``
+  in the version string, it will be replaced with ``to_pattern``.
 
 Search in a Webpage
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ Contents
 * `Version Source Files <#version-source-files>`_
 
   * `Configuration Section <#configuration-section>`_
+  * `Global Optons <#global-options>`_
   * `Search in a Webpage <#search-in-a-webpage>`_
   * `Find with a Command <#find-with-a-command>`_
   * `Check AUR <#check-aur>`_

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,17 @@ proxy
 max_concurrent
   Max number of concurrent jobs. Default: 20.
 
+Global Options
+--------------
+The following options applies to all checkers.
+
+prefix
+  Strip the prefix string if the version string starts with it.
+
+from_pattern, to_pattern
+  Both are Python-compatible regular expressions. If ``from_pattern`` is found
+  in the version string, it will be replaced with ``to_pattern``
+
 Search in a Webpage
 -------------------
 Search through a specific webpage for the version string. This type of version finding has these fields:

--- a/README.rst
+++ b/README.rst
@@ -127,14 +127,21 @@ max_concurrent
 
 Global Options
 --------------
-The following options applies to all checkers.
+The following options apply to all checkers.
 
 prefix
-  Strip the prefix string if the version string starts with it.
+  Strip the prefix string if the version string starts with it. Otherwise the
+  version string is returned as-is.
 
 from_pattern, to_pattern
   Both are Python-compatible regular expressions. If ``from_pattern`` is found
   in the version string, it will be replaced with ``to_pattern``.
+
+If both ``prefix`` and ``from_pattern``/``to_pattern`` are used,
+``from_pattern``/``to_pattern`` are ignored. If you want to strip the prefix
+and then do something special, just use ``from_pattern```/``to_pattern``. For
+example, the transformation of ``v1_1_0`` => ``1.1.0`` can be achieved with
+``from_pattern = v(\d+)_(\d+)_(\d+)`` and ``to_pattern = \1.\2.\3``.
 
 Search in a Webpage
 -------------------

--- a/nvchecker/get_version.py
+++ b/nvchecker/get_version.py
@@ -43,7 +43,10 @@ async def get_version(name, conf):
       version = await func(name, conf)
       if version:
         version = version.replace('\n', ' ')
-        version = substitute_version(version, name, conf)
+        try:
+          version = substitute_version(version, name, conf)
+        except (ValueError, re.error):
+          logger.exception('error occured in version substitutions for %s', name)
       return version
   else:
     logger.error('%s: no idea to get version info.', name)

--- a/nvchecker/get_version.py
+++ b/nvchecker/get_version.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2013-2017 lilydjwg <lilydjwg@gmail.com>, et al.
 
 import logging
+import re
 from importlib import import_module
 
 logger = logging.getLogger(__name__)
@@ -13,13 +14,45 @@ handler_precedence = (
   'anitya',
 )
 
+def substitute_version(version, name, conf):
+  '''
+  Substitute the version string via defined rules in the configuration file.
+  Accepted rules are:
+
+  * from_pattern, to_pattern: Both should be Python regular expressions.
+    `from_pattern` found in the version string will be substituted to
+    `to_pattern`.
+  * prefix: If the version string starts with `prefix`, the prefix is removed.
+    Otherwise the version string is returned as-is.
+
+  If both prefix and from_pattern/to_pattern are used, from_pattern/to_pattern
+  are ignored.
+  '''
+  prefix = conf.get('prefix')
+  if prefix:
+    if version.startswith(prefix):
+      version = version[len(prefix):]
+    return version
+
+  from_pattern = conf.get('from_pattern')
+  if from_pattern:
+    to_pattern = conf.get('to_pattern')
+    if not to_pattern:
+      raise ValueError('%s: from_pattern exists but to_pattern doesn\'t', name)
+
+    return re.sub(from_pattern, to_pattern, version)
+
+  # No substitution rules found. Just return the original version string.
+  return version
+
 async def get_version(name, conf):
   for key in handler_precedence:
     if key in conf:
       func = import_module('.source.' + key, __package__).get_version
       version = await func(name, conf)
       if version:
-        version.replace('\n', ' ')
+        version = version.replace('\n', ' ')
+        version = substitute_version(version, name, conf)
       return version
   else:
     logger.error('%s: no idea to get version info.', name)

--- a/nvchecker/get_version.py
+++ b/nvchecker/get_version.py
@@ -17,16 +17,7 @@ handler_precedence = (
 def substitute_version(version, name, conf):
   '''
   Substitute the version string via defined rules in the configuration file.
-  Accepted rules are:
-
-  * from_pattern, to_pattern: Both should be Python regular expressions.
-    `from_pattern` found in the version string will be substituted to
-    `to_pattern`.
-  * prefix: If the version string starts with `prefix`, the prefix is removed.
-    Otherwise the version string is returned as-is.
-
-  If both prefix and from_pattern/to_pattern are used, from_pattern/to_pattern
-  are ignored.
+  See README.rst#global-options for details.
   '''
   prefix = conf.get('prefix')
   if prefix:

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -1,0 +1,17 @@
+# MIT licensed
+# Copyright (c) 2013-2017 lilydjwg <lilydjwg@gmail.com>, et al.
+
+import pytest
+pytestmark = pytest.mark.asyncio
+
+async def test_substitute_prefix(get_version):
+    assert await get_version("example", {"manual": "v1.0", "prefix": "v"}) == "1.0"
+
+async def test_substitute_prefix_missing_ok(get_version):
+    assert await get_version("example", {"manual": "1.0", "prefix": "v"}) == "1.0"
+
+async def test_substitute_regex(get_version):
+    assert await get_version("example", {"manual": "r15c", "from_pattern": r"r(\d+)([a-z])", "to_pattern": r"r\1.\2"}) == "r15.c"
+
+async def test_substitute_regex_missing_ok(get_version):
+    assert await get_version("example", {"manual": "r15", "from_pattern": r"r(\d+)([a-z])", "to_pattern": r"r\1.\2"}) == "r15"

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -15,3 +15,6 @@ async def test_substitute_regex(get_version):
 
 async def test_substitute_regex_missing_ok(get_version):
     assert await get_version("example", {"manual": "r15", "from_pattern": r"r(\d+)([a-z])", "to_pattern": r"r\1.\2"}) == "r15"
+
+async def test_substitute_prefix_has_higher_priority(get_version):
+    assert await get_version("example", {"manual": "r15", "prefix": "r", "from_pattern": "r(\d+)", "to_pattern": "R\1"}) == "15"


### PR DESCRIPTION
Example use cases are in tests. Real usages can be found at https://github.com/yan12125/aur/blob/master/nvchecker.ini

This PR also fixes a possible bug from ac6616afd6016ed5e47ba1aaab62993471ed66fa. I'm not sure what's the scenario so I didn't add a test for that.