### PR TITLE
Support android sdk packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ Contents
   * `Check Debian Linux official packages <#check-debian-linux-official-packages>`_
   * `Check Ubuntu Linux official packages <#check-ubuntu-linux-official-packages>`_
   * `Check Anitya (release-monitoring.org) <#check-anitya>`_
+  * `Check Android SDK <#check-android-sdk>`_
   * `Manually updating <#manually-updating>`_
   * `Version Control System (VCS) (git, hg, svn, bzr) <#version-control-system-vcs-git-hg-svn-bzr>`_
   * `Other <#other>`_
@@ -379,6 +380,16 @@ This enables you to track updates from `Anitya <https://release-monitoring.org/>
 
 anitya
   ``distro/package``, where ``distro`` can be a lot of things like "fedora", "arch linux", "gentoo", etc. ``package`` is the package name of the chosen distribution.
+
+Check Android SDK
+-----------------
+This enables you to track updates of Android SDK packages listed in ``sdkmanager --list``.
+
+android_sdk
+  The package path prefix. This value is matched against the ``path`` attribute in all <remotePackage> nodes in an SDK manifest XML. The first match is used for version comparisions.
+
+repo
+  Should be one of ``addon`` or ``package``. Packages in ``addon2-1.xml`` use ``addon`` and packages in ``repository2-1.xml`` use ``package``.
 
 Manually updating
 -----------------

--- a/nvchecker/get_version.py
+++ b/nvchecker/get_version.py
@@ -11,7 +11,7 @@ handler_precedence = (
   'gems', 'pacman',
   'cmd', 'bitbucket', 'regex', 'manual', 'vcs',
   'cratesio', 'npm', 'hackage', 'cpan', 'gitlab', 'packagist',
-  'anitya',
+  'anitya', 'android_sdk',
 )
 
 def substitute_version(version, name, conf):

--- a/nvchecker/source/android_sdk.py
+++ b/nvchecker/source/android_sdk.py
@@ -1,0 +1,44 @@
+# MIT licensed
+# Copyright (c) 2013-2017 lilydjwg <lilydjwg@gmail.com>, et al.
+
+import os
+import re
+from xml.etree import ElementTree
+
+from . import session
+
+ANDROID_REPO_MANIFESTS = {
+  'addon': 'https://dl.google.com/android/repository/addon2-1.xml',
+  'package': 'https://dl.google.com/android/repository/repository2-1.xml',
+}
+
+async def get_version(name, conf):
+  repo_xml_url = ANDROID_REPO_MANIFESTS[conf['repo']]
+  pkg_path_prefix = conf['android_sdk']
+
+  async with session.get(repo_xml_url) as res:
+    data = (await res.read()).decode('utf-8')
+
+  repo_manifest = ElementTree.fromstring(data)
+  for pkg in repo_manifest.findall('.//remotePackage'):
+    if not pkg.attrib['path'].startswith(pkg_path_prefix):
+      continue
+    for archive in pkg.findall('./archives/archive'):
+      host_os = archive.find('./host-os')
+      if host_os and host_os.text != 'linux':
+        continue
+      archive_url = archive.find('./complete/url').text
+      # revision
+      rev = pkg.find('./revision')
+      rev_strs = []
+      for part in ('major', 'minor', 'micro'):
+        part_node = rev.find('./' + part)
+        if part_node is not None:
+          rev_strs.append(part_node.text)
+      # release number
+      filename, ext = os.path.splitext(archive_url)
+      rel_str = filename.rsplit('-')[-1]
+      mobj = re.match(r'r\d+', rel_str)
+      if mobj:
+        rev_strs.append(rel_str)
+      return '.'.join(rev_strs)

--- a/nvchecker/source/android_sdk.py
+++ b/nvchecker/source/android_sdk.py
@@ -1,5 +1,5 @@
 # MIT licensed
-# Copyright (c) 2013-2017 lilydjwg <lilydjwg@gmail.com>, et al.
+# Copyright (c) 2017 Yen Chi Hsuan <yan12125 at gmail dot com>
 
 import os
 import re
@@ -7,19 +7,33 @@ from xml.etree import ElementTree
 
 from . import session
 
-ANDROID_REPO_MANIFESTS = {
+_ANDROID_REPO_MANIFESTS = {
   'addon': 'https://dl.google.com/android/repository/addon2-1.xml',
   'package': 'https://dl.google.com/android/repository/repository2-1.xml',
 }
 
-async def get_version(name, conf):
-  repo_xml_url = ANDROID_REPO_MANIFESTS[conf['repo']]
-  pkg_path_prefix = conf['android_sdk']
+_repo_manifests_cache = {}
+
+async def _get_repo_manifest(repo):
+  if repo in _repo_manifests_cache:
+    return _repo_manifests_cache[repo]
+
+  repo_xml_url = _ANDROID_REPO_MANIFESTS[repo]
 
   async with session.get(repo_xml_url) as res:
     data = (await res.read()).decode('utf-8')
 
   repo_manifest = ElementTree.fromstring(data)
+  _repo_manifests_cache[repo] = repo_manifest
+
+  return repo_manifest
+
+async def get_version(name, conf):
+  repo = conf['repo']
+  pkg_path_prefix = conf['android_sdk']
+
+  repo_manifest = await _get_repo_manifest(repo)
+
   for pkg in repo_manifest.findall('.//remotePackage'):
     if not pkg.attrib['path'].startswith(pkg_path_prefix):
       continue

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -1,5 +1,5 @@
 # MIT licensed
-# Copyright (c) 2013-2017 lilydjwg <lilydjwg@gmail.com>, et al.
+# Copyright (c) 2017 Yen Chi Hsuan <yan12125 at gmail dot com>
 
 import pytest
 pytestmark = pytest.mark.asyncio

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -1,0 +1,11 @@
+# MIT licensed
+# Copyright (c) 2013-2017 lilydjwg <lilydjwg@gmail.com>, et al.
+
+import pytest
+pytestmark = pytest.mark.asyncio
+
+async def test_android_addon(get_version):
+    assert await get_version("android-google-play-apk-expansion", {"android_sdk": "extras;google;market_apk_expansion", "repo": "addon"}) == "1.r03"
+
+async def test_android_package(get_version):
+    assert await get_version("android-sdk-cmake", {"android_sdk": "cmake;", "repo": "package"}) == "3.6.4111459"


### PR DESCRIPTION
There are no official documents for Android SDK package manifests (repository2-1.xml and addon2-1.xml). The parsing logic is based on my observations with the help of [codes for the official ```sdkmanager``` client](https://android.googlesource.com/platform/tools/base/+/studio-master-dev).