### PR TITLE
Add missing ok

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,6 +177,10 @@ from_pattern, to_pattern
   Both are Python-compatible regular expressions. If ``from_pattern`` is found
   in the version string, it will be replaced with ``to_pattern``.
 
+missing_ok
+  Suppress warnings and errors if a version checking module finds nothing.
+  Currently only ``regex`` supports it.
+
 If both ``prefix`` and ``from_pattern``/``to_pattern`` are used,
 ``from_pattern``/``to_pattern`` are ignored. If you want to strip the prefix
 and then do something special, just use ``from_pattern```/``to_pattern``. For

--- a/nvchecker/core.py
+++ b/nvchecker/core.py
@@ -176,7 +176,8 @@ class Source:
       elif result is not None:
         self.print_version_update(name, result)
       else:
-        logger.warn('no-result', name=name)
+        if not conf.getboolean('missing_ok', False):
+          logger.warn('no-result', name=name)
         self.on_no_result(name)
 
     if self.newver:

--- a/nvchecker/source/regex.py
+++ b/nvchecker/source/regex.py
@@ -34,5 +34,6 @@ async def get_version(name, conf, **kwargs):
       version = max(regex.findall(body), key=sort_version_key)
     except ValueError:
       version = None
-      logger.error('version string not found.', name=name)
+      if not conf.getboolean('missing_ok', False):
+        logger.error('version string not found.', name=name)
     return version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import configparser
 import pytest
 import asyncio
 import io
+import structlog
 
 from nvchecker.get_version import get_version as _get_version
 from nvchecker.core import Source
@@ -53,3 +54,12 @@ def event_loop(request):
     """
     loop = asyncio.get_event_loop()
     yield loop
+
+@pytest.fixture(scope="module")
+def raise_on_logger_msg():
+    def proc(logger, method_name, event_dict):
+        if method_name in ('warn', 'error'):
+            raise RuntimeError(event_dict['event'])
+        return event_dict['event']
+
+    structlog.configure([proc])

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -18,3 +18,10 @@ async def test_regex(get_version):
         "url": "https://example.net/",
         "regex": 'for (\w+) examples',
     }) == "illustrative"
+
+async def test_missing_ok(get_version, raise_on_logger_msg):
+    assert await get_version("example", {
+        "url": "https://example.net/",
+        "regex": "foobar",
+        "missing_ok": True,
+    }) is None

--- a/tests/test_ubuntupkg.py
+++ b/tests/test_ubuntupkg.py
@@ -19,4 +19,4 @@ async def test_ubuntupkg_suite(get_version):
 
 @flaky
 async def test_ubuntupkg_suite_with_paging(get_version):
-    assert await get_version("ffmpeg", {"ubuntupkg": None, "suite": "xenial"}) == "7:2.8.14-0ubuntu0.16.04.1"
+    assert await get_version("ffmpeg", {"ubuntupkg": None, "suite": "xenial"}) == "7:2.8.15-0ubuntu0.16.04.1"


### PR DESCRIPTION
I searched on the [Android NDK downloads page](https://developer.android.com/ndk/downloads/index.html) to see if there's a new version for the package `android-ndk-beta`. When the stable release (e.g., r18) is out, beta versions (e.g., r18 beta 2) are removed from the page. In this case I'd like to simply ignore no-result warnings.