### PR TITLE
Workaround some pycurl.error issues

### DIFF
--- a/nvchecker/source/pypi.py
+++ b/nvchecker/source/pypi.py
@@ -3,7 +3,7 @@
 
 from .simple_json import simple_json
 
-PYPI_URL = 'https://pypi.python.org/pypi/%s/json'
+PYPI_URL = 'https://pypi.org/pypi/%s/json'
 
 def _version_from_json(data):
   return data['info']['version']


### PR DESCRIPTION
In my experiments, pycurl.error issues [1][2] do not appear if no 30x redirection involved.

Tested with https://github.com/tornadoweb/tornado/files/2624772/nv.log

[1] https://github.com/tornadoweb/tornado/issues/2542
[2] https://github.com/curl/curl/issues/3324