### PR TITLE
Fix running on Python 3.8

### DIFF
--- a/nvchecker/lib/nicelogger.py
+++ b/nvchecker/lib/nicelogger.py
@@ -13,7 +13,7 @@ import logging
 
 class TornadoLogFormatter(logging.Formatter):
   def __init__(self, color, *args, **kwargs):
-    super().__init__(self, *args, **kwargs)
+    super().__init__(*args, **kwargs)
     self._color = color
     if color:
       import curses

--- a/nvchecker/slogconf.py
+++ b/nvchecker/slogconf.py
@@ -64,7 +64,7 @@ class _Logger(logging.Logger):
 
   _structlog_dir = os.path.dirname(structlog.__file__)
 
-  def findCaller(self, stack_info=False):
+  def findCaller(self, stack_info=False, stacklevel=1):
     """
     Find the stack frame of the caller so that we can note the source
     file name, line number and function name.
@@ -74,6 +74,12 @@ class _Logger(logging.Logger):
     #IronPython isn't run with -X:Frames.
     if f is not None:
       f = f.f_back
+    orig_f = f
+    while f and stacklevel > 1:
+      f = f.f_back
+      stacklevel -= 1
+    if not f:
+      f = orig_f
     rv = "(unknown file)", 0, "(unknown function)", None
     while hasattr(f, "f_code"):
       co = f.f_code


### PR DESCRIPTION
Fix the following 2 errors when running on Python 3.8

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yen/Projects/nvchecker/nvchecker/main.py", line 33, in main
    if core.process_common_arguments(args):
  File "/home/yen/Projects/nvchecker/nvchecker/core.py", line 46, in process_common_arguments
    nicelogger.enable_pretty_logging(
  File "/home/yen/Projects/nvchecker/nvchecker/lib/nicelogger.py", line 93, in enable_pretty_logging
    formatter = TornadoLogFormatter(color=color)
  File "/home/yen/Projects/nvchecker/nvchecker/lib/nicelogger.py", line 16, in __init__
    super().__init__(self, *args, **kwargs)
  File "/usr/lib/python3.8/logging/__init__.py", line 589, in __init__
    self._style.validate()
  File "/usr/lib/python3.8/logging/__init__.py", line 441, in validate
    if not self.validation_pattern.search(self._fmt):
TypeError: expected string or bytes-like object
```

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yen/Projects/nvchecker/nvchecker/main.py", line 42, in main
    ioloop.run_until_complete(s.check())
  File "/usr/lib/python3.8/asyncio/base_events.py", line 589, in run_until_complete
    return future.result()
  File "/home/yen/Projects/nvchecker/nvchecker/core.py", line 177, in check
    self.print_version_update(name, result)
  File "/home/yen/Projects/nvchecker/nvchecker/core.py", line 190, in print_version_update
    logger.info('updated', name=name, version=version, old_version=oldver)
  File "/home/yen/.local/lib/python3.8/site-packages/structlog/_base.py", line 191, in _proxy_to_logger
    args, kw = self._process_event(method_name, event, event_kw)
  File "/home/yen/.local/lib/python3.8/site-packages/structlog/_base.py", line 151, in _process_event
    event_dict = proc(self._logger, method_name, event_dict)
  File "/home/yen/Projects/nvchecker/nvchecker/slogconf.py", line 48, in stdlib_renderer
    getattr(logger, level)(
  File "/usr/lib/python3.8/logging/__init__.py", line 1441, in info
    self._log(INFO, msg, args, **kwargs)
  File "/usr/lib/python3.8/logging/__init__.py", line 1572, in _log
    fn, lno, func, sinfo = self.findCaller(stack_info, stacklevel)
TypeError: findCaller() takes from 1 to 2 positional arguments but 3 were given
```

To fix the second issue, I backported relevant CPython changes [1] to slogconf.py

Test command: `python3.8 -c 'from nvchecker.main import main; main()' sample_source.ini`

[1] https://github.com/python/cpython/commit/dde9fdbe453925279ac3d2a6a72102f6f9ef247c#diff-c11fc567cf5b6e518eb855c23b5599bcR1400