### PR TITLE
Add use_pre_release for pypi source

### DIFF
--- a/nvchecker/source/pypi.py
+++ b/nvchecker/source/pypi.py
@@ -19,7 +19,7 @@ async def get_version(name, conf, **kwargs):
     data = await res.json()
 
   if use_pre_release:
-    version = list(data['releases'].keys())[-1]
+    version = sorted(data['releases'].keys())[-1]
   else:
     version = data['info']['version']
   return version

--- a/nvchecker/source/pypi.py
+++ b/nvchecker/source/pypi.py
@@ -11,9 +11,9 @@ async def get_version(name, conf, **kwargs):
 
   headers = {
     'Accept': 'application/json',
-    'User-Agent': 'lilydjwg/nvchecker'
+    'User-Agent': 'lilydjwg/nvchecker',
   }
-  url = 'https://pypi.org/pypi/{}/json'.format((package))
+  url = 'https://pypi.org/pypi/{}/json'.format(package)
 
   async with session.get(url) as res:
     data = await res.json()

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -6,3 +6,9 @@ pytestmark = pytest.mark.asyncio
 
 async def test_pypi(get_version):
     assert await get_version("example", {"pypi": None}) == "0.1.0"
+
+async def test_pypi_release(get_version):
+    assert await get_version("example-test-package", {"pypi": None}) == "1.0.0"
+
+async def test_pypi_pre_release(get_version):
+    assert await get_version("example-test-package", {"pypi": None, "use_pre_release": 1}) == "1.0.1a1"

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -8,7 +8,7 @@ async def test_pypi(get_version):
     assert await get_version("example", {"pypi": None}) == "0.1.0"
 
 async def test_pypi_release(get_version):
-    assert await get_version("example-test-package", {"pypi": None}) == "1.0.0"
+    assert await get_version("example-test-package", {"pypi": "example-test-package"}) == "1.0.0"
 
 async def test_pypi_pre_release(get_version):
-    assert await get_version("example-test-package", {"pypi": None, "use_pre_release": 1}) == "1.0.1a1"
+    assert await get_version("example-test-package", {"pypi": "example-test-package", "use_pre_release": 1}) == "1.0.1a1"


### PR DESCRIPTION
Features
- Use pre release version for pypi source

Commits
- pypi: use_pre_release support

Signed-off-by: Bruce Zhang <zttt183525594@gmail.com>