### PR TITLE
Improve tests

### DIFF
--- a/nvchecker/source/github.py
+++ b/nvchecker/source/github.py
@@ -110,9 +110,10 @@ async def max_tag(
       else:
         url = next_page_url
 
-  logger.error('No tag found in upstream repository.',
-                name=name,
-                include_tags_pattern=include_tags_pattern)
+  if not tags:
+    logger.error('No tag found in upstream repository.',
+                  name=name,
+                  include_tags_pattern=include_tags_pattern)
   return tags
 
 def get_next_page_url(links):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,8 @@ def event_loop(request):
 def raise_on_logger_msg():
   def proc(logger, method_name, event_dict):
     if method_name in ('warn', 'error'):
+      if 'exc_info' in event_dict:
+        raise event_dict['exc_info']
       raise RuntimeError(event_dict['event'])
     return event_dict['event']
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def event_loop(request):
   loop = asyncio.get_event_loop()
   yield loop
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session", autouse=True)
 def raise_on_logger_msg():
   def proc(logger, method_name, event_dict):
     if method_name in ('warn', 'error'):

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -19,7 +19,7 @@ async def test_regex(get_version):
         "regex": 'for (\w+) examples',
     }) == "illustrative"
 
-async def test_missing_ok(get_version, raise_on_logger_msg):
+async def test_missing_ok(get_version):
     assert await get_version("example", {
         "url": "http://example.net/",
         "regex": "foobar",


### PR DESCRIPTION
I got "No tag found in upstream repository" errors in packages using `use_max_tag`. I was curious why it's not caught by tests, and found out that logger.warn and logger.error in tests will not trigger an error.

This pull request is incomplete as some tests are still red.