### PR TITLE
Allow using valueless keys with numbered names

### DIFF
--- a/nvchecker/source/__init__.py
+++ b/nvchecker/source/__init__.py
@@ -1,6 +1,8 @@
 # MIT licensed
 # Copyright (c) 2013-2017 lilydjwg <lilydjwg@gmail.com>, et al.
 
+import re
+
 try:
   import tornado, pycurl
   # connection reuse, http/2
@@ -20,9 +22,15 @@ __all__ = m.__all__
 for x in __all__:
   globals()[x] = getattr(m, x)
 
+def strip_number(name):
+  mobj = re.match(r'^(.+):\d+$', name)
+  if mobj:
+    return mobj.group(1)
+  return name
+
 def conf_cacheable_with_name(key):
   def get_cacheable_conf(name, conf):
     conf = dict(conf)
-    conf[key] = conf.get(key) or name
+    conf[key] = conf.get(key) or strip_number(name)
     return conf
   return get_cacheable_conf

--- a/nvchecker/source/archpkg.py
+++ b/nvchecker/source/archpkg.py
@@ -3,7 +3,7 @@
 
 import structlog
 
-from . import session, conf_cacheable_with_name
+from . import session, conf_cacheable_with_name, strip_number
 
 logger = structlog.get_logger(logger_name=__name__)
 
@@ -12,7 +12,7 @@ URL = 'https://www.archlinux.org/packages/search/json/'
 get_cacheable_conf = conf_cacheable_with_name('archpkg')
 
 async def get_version(name, conf, **kwargs):
-  pkg = conf.get('archpkg') or name
+  pkg = conf.get('archpkg') or strip_number(name)
   strip_release = conf.getboolean('strip-release', False)
   async with session.get(URL, params={"name": pkg}) as res:
     data = await res.json()

--- a/nvchecker/source/aur.py
+++ b/nvchecker/source/aur.py
@@ -4,7 +4,7 @@
 import structlog
 from datetime import datetime
 
-from . import session, conf_cacheable_with_name
+from . import session, conf_cacheable_with_name, strip_number
 
 logger = structlog.get_logger(logger_name=__name__)
 
@@ -13,7 +13,7 @@ AUR_URL = 'https://aur.archlinux.org/rpc/?v=5&type=info&arg[]='
 get_cacheable_conf = conf_cacheable_with_name('aur')
 
 async def get_version(name, conf, **kwargs):
-  aurname = conf.get('aur') or name
+  aurname = conf.get('aur') or strip_number(name)
   use_last_modified = conf.getboolean('use_last_modified', False)
   strip_release = conf.getboolean('strip-release', False)
   async with session.get(AUR_URL, params={"v": 5, "type": "info", "arg[]": aurname}) as res:

--- a/nvchecker/source/cratesio.py
+++ b/nvchecker/source/cratesio.py
@@ -1,14 +1,14 @@
 # MIT licensed
 # Copyright (c) 2013-2018 lilydjwg <lilydjwg@gmail.com>, et al.
 
-from . import session, conf_cacheable_with_name
+from . import session, conf_cacheable_with_name, strip_number
 
 API_URL = 'https://crates.io/api/v1/crates/%s'
 
 get_cacheable_conf = conf_cacheable_with_name('cratesio')
 
 async def get_version(name, conf, **kwargs):
-  name = conf.get('cratesio') or name
+  name = conf.get('cratesio') or strip_number(name)
   async with session.get(API_URL % name) as res:
     data = await res.json()
   version = [v['num'] for v in data['versions'] if not v['yanked']][0]

--- a/nvchecker/source/debianpkg.py
+++ b/nvchecker/source/debianpkg.py
@@ -3,7 +3,7 @@
 
 import structlog
 
-from . import session, conf_cacheable_with_name
+from . import session, conf_cacheable_with_name, strip_number
 
 logger = structlog.get_logger(logger_name=__name__)
 
@@ -12,7 +12,7 @@ URL = 'https://sources.debian.org/api/src/%(pkgname)s/?suite=%(suite)s'
 get_cacheable_conf = conf_cacheable_with_name('debianpkg')
 
 async def get_version(name, conf, **kwargs):
-  pkg = conf.get('debianpkg') or name
+  pkg = conf.get('debianpkg') or strip_number(name)
   strip_release = conf.getboolean('strip-release', False)
   suite = conf.get('suite') or "sid"
   url = URL % {"pkgname": pkg, "suite": suite}

--- a/nvchecker/source/pacman.py
+++ b/nvchecker/source/pacman.py
@@ -1,12 +1,12 @@
 # MIT licensed
 # Copyright (c) 2013-2017 lilydjwg <lilydjwg@gmail.com>, et al.
 
-from . import cmd, conf_cacheable_with_name
+from . import cmd, conf_cacheable_with_name, strip_number
 
 get_cacheable_conf = conf_cacheable_with_name('debianpkg')
 
 async def get_version(name, conf, **kwargs):
-  referree = conf.get('pacman') or name
+  referree = conf.get('pacman') or strip_number(name)
   c = "LANG=C pacman -Si %s | grep -F Version | awk '{print $3}'" % referree
   conf['cmd'] = c
   strip_release = conf.getboolean('strip-release', False)

--- a/nvchecker/source/pypi.py
+++ b/nvchecker/source/pypi.py
@@ -1,12 +1,12 @@
 # MIT licensed
 # Copyright (c) 2013-2017 lilydjwg <lilydjwg@gmail.com>, et al.
 
-from . import conf_cacheable_with_name, session
+from . import conf_cacheable_with_name, session, strip_number
 
 get_cacheable_conf = conf_cacheable_with_name('pypi')
 
 async def get_version(name, conf, **kwargs):
-  package = conf.get('pypi') or name
+  package = conf.get('pypi') or strip_number(name)
   use_pre_release = conf.getboolean('use_pre_release', False)
 
   url = 'https://pypi.org/pypi/{}/json'.format(package)

--- a/nvchecker/source/simple_json.py
+++ b/nvchecker/source/simple_json.py
@@ -1,12 +1,12 @@
 # MIT licensed
 # Copyright (c) 2013-2017 lilydjwg <lilydjwg@gmail.com>, et al.
 
-from . import session, conf_cacheable_with_name
+from . import session, conf_cacheable_with_name, strip_number
 
 def simple_json(urlpat, confkey, version_from_json):
 
   async def get_version(name, conf, **kwargs):
-    repo = conf.get(confkey) or name
+    repo = conf.get(confkey) or strip_number(name)
     url = urlpat % repo
     kwargs = {}
     if conf.get('proxy'):

--- a/nvchecker/source/ubuntupkg.py
+++ b/nvchecker/source/ubuntupkg.py
@@ -3,7 +3,7 @@
 
 import structlog
 
-from . import session, conf_cacheable_with_name
+from . import session, conf_cacheable_with_name, strip_number
 
 logger = structlog.get_logger(logger_name=__name__)
 
@@ -12,7 +12,7 @@ URL = 'https://api.launchpad.net/1.0/ubuntu/+archive/primary?ws.op=getPublishedS
 get_cacheable_conf = conf_cacheable_with_name('ubuntupkg')
 
 async def get_version(name, conf, **kwargs):
-  pkg = conf.get('ubuntupkg') or name
+  pkg = conf.get('ubuntupkg') or strip_number(name)
   strip_release = conf.getboolean('strip-release', False)
   suite = conf.get('suite')
   url = URL % pkg

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,9 @@ async def run_source():
 
 @pytest.fixture(scope="module")
 async def get_version():
-  async def __call__(name, config):
+  async def __call__(name, config, clear_cache=False):
+    if clear_cache:
+      _cache.clear()
 
     if isinstance(config, dict):
       _config = configparser.ConfigParser(dict_type=dict, allow_no_value=True)

--- a/tests/test_archpkg.py
+++ b/tests/test_archpkg.py
@@ -12,3 +12,7 @@ async def test_archpkg(get_version):
 @flaky
 async def test_archpkg_strip_release(get_version):
     assert await get_version("ipw2100-fw", {"archpkg": None, "strip-release": 1}) == "1.3"
+
+@flaky
+async def test_archpkg_numbered(get_version):
+    assert await get_version("ipw2100-fw:1", {"archpkg": None}, clear_cache=True) == "1.3-9"

--- a/tests/test_aur.py
+++ b/tests/test_aur.py
@@ -16,3 +16,7 @@ async def test_aur_strip_release(get_version):
 @flaky(max_runs=10)
 async def test_aur_use_last_modified(get_version):
     assert await get_version("ssed", {"aur": None, 'use_last_modified': True}) == "3.62-2-20150725052412"
+
+@flaky(max_runs=10)
+async def test_aur_numbered(get_version):
+    assert await get_version("ssed:1", {"aur": None}, clear_cache=True) == "3.62-2"

--- a/tests/test_cpan.py
+++ b/tests/test_cpan.py
@@ -6,3 +6,6 @@ pytestmark = pytest.mark.asyncio
 
 async def test_cpan(get_version):
     assert await get_version("POE-Component-Server-HTTPServer", {"cpan": None}) == "0.9.2"
+
+async def test_cpan_numbered(get_version):
+    assert await get_version("POE-Component-Server-HTTPServer:1", {"cpan": None}, clear_cache=True) == "0.9.2"

--- a/tests/test_cratesio.py
+++ b/tests/test_cratesio.py
@@ -6,3 +6,6 @@ pytestmark = pytest.mark.asyncio
 
 async def test_cratesio(get_version):
     assert await get_version("example", {"cratesio": None}) == "0.1.0"
+
+async def test_cratesio_numbered(get_version):
+    assert await get_version("example:1", {"cratesio": None}, clear_cache=True) == "0.1.0"

--- a/tests/test_debianpkg.py
+++ b/tests/test_debianpkg.py
@@ -16,3 +16,7 @@ async def test_debianpkg_strip_release(get_version):
 @flaky(max_runs=10)
 async def test_debianpkg_suite(get_version):
     assert await get_version("sigrok-firmware-fx2lafw", {"debianpkg": None, "suite": "jessie"}) == "0.1.2-1"
+
+@flaky(max_runs=10)
+async def test_debianpkg_numbered(get_version):
+    assert await get_version("sigrok-firmware-fx2lafw:1", {"debianpkg": None}, clear_cache=True) == "0.1.6-1"

--- a/tests/test_gems.py
+++ b/tests/test_gems.py
@@ -6,3 +6,6 @@ pytestmark = pytest.mark.asyncio
 
 async def test_gems(get_version):
     assert await get_version("example", {"gems": None}) == "1.0.2"
+
+async def test_gems_numbered(get_version):
+    assert await get_version("example:1", {"gems": None}, clear_cache=True) == "1.0.2"

--- a/tests/test_hackage.py
+++ b/tests/test_hackage.py
@@ -6,3 +6,6 @@ pytestmark = pytest.mark.asyncio
 
 async def test_hackage(get_version):
     assert await get_version("sessions", {"hackage": None}) == "2008.7.18"
+
+async def test_hackage_numbered(get_version):
+    assert await get_version("sessions:1", {"hackage": None}, clear_cache=True) == "2008.7.18"

--- a/tests/test_npm.py
+++ b/tests/test_npm.py
@@ -6,3 +6,6 @@ pytestmark = pytest.mark.asyncio
 
 async def test_npm(get_version):
     assert await get_version("example", {"npm": None}) == "0.0.0"
+
+async def test_npm_numbered(get_version):
+    assert await get_version("example:1", {"npm": None}, clear_cache=True) == "0.0.0"

--- a/tests/test_packagist.py
+++ b/tests/test_packagist.py
@@ -6,3 +6,6 @@ pytestmark = pytest.mark.asyncio
 
 async def test_packagist(get_version):
     assert await get_version("butterfly/example-web-application", {"packagist": None}) == "1.2.0"
+
+async def test_packagist_numbered(get_version):
+    assert await get_version("butterfly/example-web-application:1", {"packagist": None}, clear_cache=True) == "1.2.0"

--- a/tests/test_pacman.py
+++ b/tests/test_pacman.py
@@ -12,3 +12,6 @@ async def test_pacman(get_version):
 
 async def test_pacman_strip_release(get_version):
     assert await get_version("ipw2100-fw", {"pacman": None, "strip-release": 1}) == "1.3"
+
+async def test_pacman_numbered(get_version):
+    assert await get_version("ipw2100-fw:1", {"pacman": None}, clear_cache=True) == "1.3-9"

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -12,3 +12,6 @@ async def test_pypi_release(get_version):
 
 async def test_pypi_pre_release(get_version):
     assert await get_version("example-test-package", {"pypi": "example-test-package", "use_pre_release": 1}) == "1.0.1a1"
+
+async def test_pypi_numbered(get_version):
+    assert await get_version("example:1", {"pypi": None}, clear_cache=True) == "0.1.0"

--- a/tests/test_ubuntupkg.py
+++ b/tests/test_ubuntupkg.py
@@ -20,3 +20,7 @@ async def test_ubuntupkg_suite(get_version):
 @flaky
 async def test_ubuntupkg_suite_with_paging(get_version):
     assert await get_version("ffmpeg", {"ubuntupkg": None, "suite": "xenial"}) == "7:2.8.15-0ubuntu0.16.04.1"
+
+@flaky
+async def test_ubuntupkg_numbered(get_version):
+    assert await get_version("sigrok-firmware-fx2lafw:1", {"ubuntupkg": None}, clear_cache=True) == "0.1.6-1"


### PR DESCRIPTION
Enabling such a lilac configuration:
```
update_on:
  - github: foo/bar
  - aur
```