### PR TITLE
Get rid of warnings from logging.warn

### DIFF
--- a/nvchecker/core.py
+++ b/nvchecker/core.py
@@ -189,7 +189,7 @@ class Source:
       else:
         conf = config[name]
         if not conf.getboolean('missing_ok', False):
-          logger.warn('no-result', name=name)
+          logger.warning('no-result', name=name)
         self.on_no_result(name)
 
     if self.newver:

--- a/nvchecker/source/regex.py
+++ b/nvchecker/source/regex.py
@@ -14,7 +14,7 @@ async def get_version(name, conf, **kwargs):
   try:
     regex = re.compile(conf['regex'])
   except sre_constants.error:
-    logger.warn('bad regex, skipped.', name=name, exc_info=True)
+    logger.warning('bad regex, skipped.', name=name, exc_info=True)
     return
 
   encoding = conf.get('encoding', 'latin1')

--- a/nvchecker/tools.py
+++ b/nvchecker/tools.py
@@ -42,7 +42,7 @@ def take():
         oldvers[name] = newvers[name]
       except KeyError:
         if args.ignore_nonexistent:
-          logger.warn('nonexistent in newver, ignored', name=name)
+          logger.warning('nonexistent in newver, ignored', name=name)
           continue
 
         logger.critical(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def event_loop(request):
 @pytest.fixture(scope="session", autouse=True)
 def raise_on_logger_msg():
   def proc(logger, method_name, event_dict):
-    if method_name in ('warn', 'error'):
+    if method_name in ('warning', 'error'):
       if 'exc_info' in event_dict:
         raise event_dict['exc_info']
       raise RuntimeError(event_dict['event'])


### PR DESCRIPTION
logging.warn is deprecated [1].

Warnings are hidden unless PYTHONWARNINGS is specified. For example:
```
$ PYTHONWARNINGS=all nvchecker foo.ini
/usr/lib/python3.7/site-packages/tornado/httputil.py:107: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  class HTTPHeaders(collections.MutableMapping):
/usr/lib/python3.7/site-packages/nvchecker/slogconf.py:49: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
  msg, exc_info = exc_info, extra=std_event,
[W 03-24 00:01:02.503 core:192] foo: no-result
sys:1: ResourceWarning: unclosed file <_io.TextIOWrapper name='foo.ini' mode='r' encoding='UTF-8'>
```

The content of foo.ini is
```
[foo]
url = https://example.com/
regex = foo
```

[1] https://docs.python.org/3/library/logging.html#logging.Logger.warning