### PR TITLE
Fix gitlab tests

### DIFF
--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -15,10 +15,10 @@ async def test_gitlab(get_version):
     assert ver.isdigit()
 
 async def test_gitlab_max_tag(get_version):
-    assert await get_version("example", {"gitlab": "gitlab-org/gitlab-test", "use_max_tag": 1}) == "v1.1.0"
+    assert await get_version("example", {"gitlab": "gitlab-org/gitlab-test", "use_max_tag": 1}) == "v1.1.1"
 
 async def test_gitlab_max_tag_with_ignored_tags(get_version):
-    assert await get_version("example", {"gitlab": "gitlab-org/gitlab-test", "use_max_tag": 1, "ignored_tags": "v1.1.0"}) == "v1.0.0"
+    assert await get_version("example", {"gitlab": "gitlab-org/gitlab-test", "use_max_tag": 1, "ignored_tags": "v1.1.0 v1.1.1"}) == "v1.0.0"
 
 async def test_gitlab_max_tag_with_include(get_version):
     assert await get_version("example", {
@@ -29,6 +29,6 @@ async def test_gitlab_max_tag_with_include(get_version):
 async def test_gitlab_max_tag_with_ignored(get_version):
     assert await get_version("example", {
         "gitlab": "gitlab-org/gitlab-test", "use_max_tag": 1,
-        "ignored": "v1.1.0",
+        "ignored": "v1.1.0 v1.1.1",
     }) == "v1.0.0"
 

--- a/tests/test_gitlab_local.py
+++ b/tests/test_gitlab_local.py
@@ -29,11 +29,11 @@ async def test_gitlab(get_version):
 
 async def test_gitlab_max_tag(get_version):
     with unset_gitlab_token_env():
-        assert await get_version("example", {"gitlab": "gitlab-org/gitlab-test", "use_max_tag": 1}) == "v1.1.0"
+        assert await get_version("example", {"gitlab": "gitlab-org/gitlab-test", "use_max_tag": 1}) == "v1.1.1"
 
 async def test_gitlab_max_tag_with_ignored_tags(get_version):
     with unset_gitlab_token_env():
         ver = await get_version("example",
-                                {"gitlab": "gitlab-org/gitlab-test", "use_max_tag": 1, "ignored_tags": "v1.1.0"})
+                                {"gitlab": "gitlab-org/gitlab-test", "use_max_tag": 1, "ignored_tags": "v1.1.0 v1.1.1"})
         assert ver == "v1.0.0"
 


### PR DESCRIPTION
The repo https://gitlab.com/gitlab-org/gitlab-test gets a new tag
v1.1.1, which is for testing a new GitLab feature [1][2].

[1] https://gitlab.com/gitlab-org/gitlab/merge_requests/17773
[2] https://gitlab.com/gitlab-org/gitlab-test/merge_requests/40