### PR TITLE
Add an APT source

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -622,7 +622,7 @@ apt
   Name of the APT package.
 
 mirror
-  URL of the repository (defaults to http://ftp.debian.org/debian/)
+  URL of the repository (defaults to http://deb.debian.org/debian/)
 
 suite
   Name of the APT repository release (jessie, wheezy, etc, defaults to sid)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -610,6 +610,32 @@ host
 
 This source returns tags and supports :ref:`list options`.
 
+Check APT repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+::
+
+  source = "apt"
+
+This enables you to track the update of an arbitary APT repository, without needing of apt and an updated local APT database.
+
+apt
+  Name of the APT package.
+
+mirror
+  URL of the repository (defaults to http://ftp.debian.org/debian/)
+
+suite
+  Name of the APT repository release (jessie, wheezy, etc, defaults to sid)
+
+repo
+  Name of the APT repository (main, contrib, etc, defaults to main)
+
+arch
+  Architecture of the repository (i386, amd64, etc, defaults to amd64)
+
+strip_release
+  Strip the release part.
+
 Manually updating
 ~~~~~~~~~~~~~~~~~
 ::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -618,8 +618,11 @@ Check APT repository
 
 This enables you to track the update of an arbitary APT repository, without needing of apt and an updated local APT database.
 
-apt
-  Name of the APT package.
+pkg
+  Name of the APT binary package.
+
+source_pkg
+  Name of the APT source package.
 
 mirror
   URL of the repository (defaults to http://deb.debian.org/debian/)
@@ -635,6 +638,8 @@ arch
 
 strip_release
   Strip the release part.
+
+Note that either pkg or source_pkg needs to be specified (but not both) or the item name will be used as package.
 
 Manually updating
 ~~~~~~~~~~~~~~~~~

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -621,7 +621,7 @@ This enables you to track the update of an arbitary APT repository, without need
 pkg
   Name of the APT binary package.
 
-source_pkg
+srcpkg
   Name of the APT source package.
 
 mirror
@@ -639,7 +639,7 @@ arch
 strip_release
   Strip the release part.
 
-Note that either pkg or source_pkg needs to be specified (but not both) or the item name will be used as package.
+Note that either pkg or srcpkg needs to be specified (but not both) or the item name will be used as pkg.
 
 Manually updating
 ~~~~~~~~~~~~~~~~~

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -625,10 +625,10 @@ srcpkg
   Name of the APT source package.
 
 mirror
-  URL of the repository (defaults to http://deb.debian.org/debian/)
+  URL of the repository.
 
 suite
-  Name of the APT repository release (jessie, wheezy, etc, defaults to sid)
+  Name of the APT repository release (jessie, wheezy, etc)
 
 repo
   Name of the APT repository (main, contrib, etc, defaults to main)

--- a/nvchecker_source/apt.py
+++ b/nvchecker_source/apt.py
@@ -22,7 +22,7 @@ async def get_url(url):
   return data.decode('utf-8')
 
 async def get_version(name, conf, *, cache, **kwargs):
-  source_pkg = conf.get('source_pkg')
+  srcpkg = conf.get('srcpkg')
   pkg = conf.get('pkg')
   mirror = conf.get('mirror', "http://deb.debian.org/debian/")
   suite = conf.get('suite', 'sid')
@@ -30,9 +30,9 @@ async def get_version(name, conf, *, cache, **kwargs):
   arch = conf.get('arch', 'amd64')
   strip_release = conf.get('strip_release', False)
 
-  if source_pkg and pkg:
-    raise GetVersionError('Setting both source_pkg and pkg is ambigious')
-  elif not source_pkg and not pkg:
+  if srcpkg and pkg:
+    raise GetVersionError('Setting both srcpkg and pkg is ambigious')
+  elif not srcpkg and not pkg:
     pkg = name
 
   apt_release = await cache.get(APT_RELEASE_URL % (mirror, suite), get_url)
@@ -49,7 +49,7 @@ async def get_version(name, conf, *, cache, **kwargs):
   for line in apt_packages.split("\n"):
     if pkg and line == "Package: " + pkg:
       pkg_found = True
-    if source_pkg and line == "Source: " + source_pkg:
+    if srcpkg and line == "Source: " + srcpkg:
       pkg_found = True
     if pkg_found and line.startswith("Version: "):
       version = line[9:]

--- a/nvchecker_source/apt.py
+++ b/nvchecker_source/apt.py
@@ -22,12 +22,18 @@ async def get_url(url):
   return data.decode('utf-8')
 
 async def get_version(name, conf, *, cache, **kwargs):
-  pkg = conf.get('apt') or name
+  source_pkg = conf.get('source_pkg')
+  pkg = conf.get('pkg')
   mirror = conf.get('mirror', "http://deb.debian.org/debian/")
   suite = conf.get('suite', 'sid')
   repo = conf.get('repo', 'main')
   arch = conf.get('arch', 'amd64')
   strip_release = conf.get('strip_release', False)
+
+  if source_pkg and pkg:
+    raise GetVersionError('Setting both source_pkg and pkg is ambigious')
+  elif not source_pkg and not pkg:
+    pkg = name
 
   apt_release = await cache.get(APT_RELEASE_URL % (mirror, suite), get_url)
   for suffix in APT_PACKAGES_SUFFIX_PREFER:
@@ -41,7 +47,9 @@ async def get_version(name, conf, *, cache, **kwargs):
 
   pkg_found = False
   for line in apt_packages.split("\n"):
-    if line == "Package: " + pkg:
+    if pkg and line == "Package: " + pkg:
+      pkg_found = True
+    if source_pkg and line == "Source: " + source_pkg:
       pkg_found = True
     if pkg_found and line.startswith("Version: "):
       version = line[9:]

--- a/nvchecker_source/apt.py
+++ b/nvchecker_source/apt.py
@@ -1,0 +1,52 @@
+# MIT licensed
+# Copyright (c) 2020 Felix Yan <felixonmars@archlinux.org>, et al.
+
+from nvchecker.api import session, GetVersionError
+
+APT_RELEASE_URL = "%s/dists/%s/Release"
+APT_PACKAGES_PATH = "%s/binary-%s/Packages%s"
+APT_PACKAGES_URL = "%s/dists/%s/%s"
+APT_PACKAGES_SUFFIX_PREFER = (".xz", ".gz", "")
+
+async def get_url(url):
+  res = await session.get(url)
+  data = res.body
+
+  if url.endswith(".xz"):
+    import lzma
+    data = lzma.decompress(data)
+  elif url.endswith(".gz"):
+    import gzip
+    data = gzip.decompress(data)
+
+  return data.decode('utf-8')
+
+async def get_version(name, conf, *, cache, **kwargs):
+  pkg = conf.get('apt') or name
+  mirror = conf.get('mirror', "http://ftp.debian.org/debian/")
+  suite = conf.get('suite', 'sid')
+  repo = conf.get('repo', 'main')
+  arch = conf.get('arch', 'amd64')
+  strip_release = conf.get('strip_release', False)
+
+  apt_release = await cache.get(APT_RELEASE_URL % (mirror, suite), get_url)
+  for suffix in APT_PACKAGES_SUFFIX_PREFER:
+    packages_path = APT_PACKAGES_PATH % (repo, arch, suffix)
+    if " " + packages_path in apt_release:
+      break
+  else:
+    raise GetVersionError('Packages file not found in APT repository')
+
+  apt_packages = await cache.get(APT_PACKAGES_URL % (mirror, suite, packages_path), get_url)
+
+  pkg_found = False
+  for line in apt_packages.split("\n"):
+    if line == "Package: " + pkg:
+      pkg_found = True
+    if pkg_found and line.startswith("Version: "):
+      version = line[9:]
+      if strip_release:
+        version = version.split("-")[0]
+      return version
+
+  raise GetVersionError('package not found in APT repository')

--- a/nvchecker_source/apt.py
+++ b/nvchecker_source/apt.py
@@ -24,8 +24,8 @@ async def get_url(url):
 async def get_version(name, conf, *, cache, **kwargs):
   srcpkg = conf.get('srcpkg')
   pkg = conf.get('pkg')
-  mirror = conf.get('mirror', "http://deb.debian.org/debian/")
-  suite = conf.get('suite', 'sid')
+  mirror = conf['mirror']
+  suite = conf['suite']
   repo = conf.get('repo', 'main')
   arch = conf.get('arch', 'amd64')
   strip_release = conf.get('strip_release', False)

--- a/nvchecker_source/apt.py
+++ b/nvchecker_source/apt.py
@@ -23,7 +23,7 @@ async def get_url(url):
 
 async def get_version(name, conf, *, cache, **kwargs):
   pkg = conf.get('apt') or name
-  mirror = conf.get('mirror', "http://ftp.debian.org/debian/")
+  mirror = conf.get('mirror', "http://deb.debian.org/debian/")
   suite = conf.get('suite', 'sid')
   repo = conf.get('repo', 'main')
   arch = conf.get('arch', 'amd64')

--- a/tests/test_apt.py
+++ b/tests/test_apt.py
@@ -10,6 +10,8 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]
 async def test_apt(get_version):
     assert await get_version("sigrok-firmware-fx2lafw", {
         "source": "apt",
+        "mirror": "http://deb.debian.org/debian/",
+        "suite": "sid",
     }) == "0.1.7-1"
 
 @flaky(max_runs=10)
@@ -17,12 +19,16 @@ async def test_apt_source_pkg(get_version):
     assert await get_version("test", {
         "source": "apt",
         "source_pkg": "golang-github-dataence-porter2",
+        "mirror": "http://deb.debian.org/debian/",
+        "suite": "sid",
     }) == "0.0~git20150829.56e4718-2"
 
 @flaky(max_runs=10)
 async def test_apt_strip_release(get_version):
     assert await get_version("sigrok-firmware-fx2lafw", {
         "source": "apt",
+        "mirror": "http://deb.debian.org/debian/",
+        "suite": "sid",
         "strip_release": 1,
     }) == "0.1.7"
 

--- a/tests/test_apt.py
+++ b/tests/test_apt.py
@@ -13,6 +13,13 @@ async def test_apt(get_version):
     }) == "0.1.7-1"
 
 @flaky(max_runs=10)
+async def test_apt_source_pkg(get_version):
+    assert await get_version("test", {
+        "source": "apt",
+        "source_pkg": "golang-github-dataence-porter2",
+    }) == "0.0~git20150829.56e4718-2"
+
+@flaky(max_runs=10)
 async def test_apt_strip_release(get_version):
     assert await get_version("sigrok-firmware-fx2lafw", {
         "source": "apt",

--- a/tests/test_apt.py
+++ b/tests/test_apt.py
@@ -1,0 +1,28 @@
+# MIT licensed
+# Copyright (c) 2020 lilydjwg <lilydjwg@gmail.com>, et al.
+# Copyright (c) 2017 Felix Yan <felixonmars@archlinux.org>, et al.
+
+from flaky import flaky
+import pytest
+pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]
+
+@flaky(max_runs=10)
+async def test_apt(get_version):
+    assert await get_version("sigrok-firmware-fx2lafw", {
+        "source": "apt",
+    }) == "0.1.7-1"
+
+@flaky(max_runs=10)
+async def test_apt_strip_release(get_version):
+    assert await get_version("sigrok-firmware-fx2lafw", {
+        "source": "apt",
+        "strip_release": 1,
+    }) == "0.1.7"
+
+@flaky(max_runs=10)
+async def test_apt_deepin(get_version):
+    assert await get_version("sigrok-firmware-fx2lafw", {
+        "source": "apt",
+        "mirror": "https://community-packages.deepin.com/deepin",
+        "suite": "apricot",
+    }) == "0.1.6-1"

--- a/tests/test_apt.py
+++ b/tests/test_apt.py
@@ -15,10 +15,10 @@ async def test_apt(get_version):
     }) == "0.1.7-1"
 
 @flaky(max_runs=10)
-async def test_apt_source_pkg(get_version):
+async def test_apt_srcpkg(get_version):
     assert await get_version("test", {
         "source": "apt",
-        "source_pkg": "golang-github-dataence-porter2",
+        "srcpkg": "golang-github-dataence-porter2",
         "mirror": "http://deb.debian.org/debian/",
         "suite": "sid",
     }) == "0.0~git20150829.56e4718-2"


### PR DESCRIPTION
This source follows the same flow apt itself uses to check for a
package's version, so it can be used to check for any APT repository
(not necessarily Debian or Ubuntu).