### PR TITLE
npm: Request abbreviated metadata to reduce download size

### DIFF
--- a/nvchecker_source/npm.py
+++ b/nvchecker_source/npm.py
@@ -5,5 +5,5 @@ NPM_URL = 'https://registry.npmjs.org/%s'
 
 async def get_version(name, conf, *, cache, **kwargs):
   key = conf.get('npm', name)
-  data = await cache.get_json(NPM_URL % key)
+  data = await cache.get_json(NPM_URL % key, headers={"Accept": "application/vnd.npm.install-v1+json"})
   return data['dist-tags']['latest']


### PR DESCRIPTION
Ref:
https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md

For `npm` it's a 10.8MiB to 1.2MiB difference.