### PR TITLE
npm: Fetch only first 1KB

### DIFF
--- a/nvchecker_source/npm.py
+++ b/nvchecker_source/npm.py
@@ -1,9 +1,23 @@
 # MIT licensed
 # Copyright (c) 2013-2020 lilydjwg <lilydjwg@gmail.com>, et al.
 
+import json
+import re
+from nvchecker.api import session
+
 NPM_URL = 'https://registry.npmjs.org/%s'
+
+async def get_first_1k(url):
+  headers = {
+    "Accept": "application/vnd.npm.install-v1+json",
+    "Range": "bytes=0-1023",
+  }
+  res = await session.get(url, headers=headers)
+  return res.body
 
 async def get_version(name, conf, *, cache, **kwargs):
   key = conf.get('npm', name)
-  data = await cache.get_json(NPM_URL % key, headers={"Accept": "application/vnd.npm.install-v1+json"})
-  return data['dist-tags']['latest']
+  data = await cache.get(NPM_URL % key, get_first_1k)
+
+  dist_tags = json.loads(re.search(b'"dist-tags":({.*?})', data).group(1))
+  return dist_tags['latest']


### PR DESCRIPTION
The result is still large even after specifying
"Accept: application/vnd.npm.install-v1+json". Since the content we need
are always at the beginning of the response, let's make it more violent.