### PR TITLE
Allow empty to_pattern

### DIFF
--- a/nvchecker/core.py
+++ b/nvchecker/core.py
@@ -250,7 +250,7 @@ def substitute_version(
   from_pattern = conf.get('from_pattern')
   if from_pattern:
     to_pattern = conf.get('to_pattern')
-    if not to_pattern:
+    if to_pattern is None:
       raise ValueError("from_pattern exists but to_pattern doesn't")
 
     return re.sub(from_pattern, to_pattern, version)

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -34,6 +34,14 @@ async def test_substitute_regex_missing_ok(get_version):
         "to_pattern": r"r\1.\2",
     }) == "r15"
 
+async def test_substitute_regex_empty_to_pattern(get_version):
+    assert await get_version("example", {
+        "source": "manual",
+        "manual": "15-debian",
+        "from_pattern": r"-\w+$",
+        "to_pattern": r"",
+    }) == "15"
+
 async def test_substitute_prefix_has_higher_priority(get_version):
     assert await get_version("example", {
         "source": "manual",


### PR DESCRIPTION
It's useful to have a partial match pattern to be replaced by an empty
string, like stripping a suffix. Let's allow it as "not to_pattern" will
reject this.