### PR TITLE
Add container source plugin

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -662,6 +662,22 @@ git
 
 This source returns tags and supports :ref:`list options`.
 
+Check container registry
+~~~~~~~~~~~~~~~~~~~~~~~~
+::
+
+  source = "container"
+
+This enables you to check tags of images on a container registry like Docker.
+
+container
+  The path for the container image. For official Docker images, use namespace ``library/`` (e.g. ``library/python``).
+
+registry
+  The container registry host. Default: ``docker.io``
+
+This source returns tags and supports :ref:`list options`.
+
 Manually updating
 ~~~~~~~~~~~~~~~~~
 ::

--- a/nvchecker/api.py
+++ b/nvchecker/api.py
@@ -1,7 +1,7 @@
 # MIT licensed
 # Copyright (c) 2020 lilydjwg <lilydjwg@gmail.com>, et al.
 
-from .httpclient import session, TemporaryError
+from .httpclient import session, TemporaryError, HTTPError
 from .util import (
   Entry, BaseWorker, RawResult, VersionResult,
   AsyncCache, KeyManager, GetVersionError,

--- a/nvchecker/httpclient/__init__.py
+++ b/nvchecker/httpclient/__init__.py
@@ -3,7 +3,7 @@
 
 from typing import Optional
 
-from .base import TemporaryError
+from .base import TemporaryError, HTTPError
 
 class Proxy:
   _obj = None

--- a/nvchecker/httpclient/base.py
+++ b/nvchecker/httpclient/base.py
@@ -86,10 +86,14 @@ class BaseSession:
     ''':meta private:'''
     raise NotImplementedError
 
-class TemporaryError(Exception):
-  '''A temporary error (e.g. network error) happens.'''
+class BaseHTTPError(Exception):
   def __init__(self, code, message, response):
     self.code = code
     self.message = message
     self.response = response
 
+class TemporaryError(BaseHTTPError):
+  '''A temporary error (e.g. network error) happens.'''
+
+class HTTPError(BaseHTTPError):
+  ''' An HTTP 4xx error happens '''

--- a/nvchecker_source/android_sdk.py
+++ b/nvchecker_source/android_sdk.py
@@ -1,6 +1,6 @@
 # MIT licensed
 # Copyright (c) 2020 lilydjwg <lilydjwg@gmail.com>, et al.
-# Copyright (c) 2017 Yen Chi Hsuan <yan12125 at gmail dot com>
+# Copyright (c) 2017 Chih-Hsuan Yen <yan12125 at gmail dot com>
 
 import os
 import re

--- a/nvchecker_source/container.py
+++ b/nvchecker_source/container.py
@@ -1,0 +1,83 @@
+# MIT licensed
+# Copyright (c) 2020 Chih-Hsuan Yen <yan12125 at gmail dot com>
+
+from typing import Dict, List, NamedTuple, Optional, Tuple
+from urllib.request import parse_http_list
+
+from nvchecker.api import session, HTTPError
+
+class AuthInfo(NamedTuple):
+  service: Optional[str]
+  realm: str
+
+def parse_www_authenticate_header(header: str) -> Tuple[str, Dict[str, str]]:
+  '''
+  Parse WWW-Authenticate header used in OAuth2 authentication for container
+  registries. This is NOT RFC-compliant!
+
+  Simplified from http.parse_www_authenticate_header in Werkzeug (BSD license)
+  '''
+  auth_type, auth_info = header.split(None, 1)
+  result = {}
+  for item in parse_http_list(auth_info):
+    name, value = item.split("=", 1)
+    if value[:1] == value[-1:] == '"':
+      value = value[1:-1]
+    result[name] = value
+  return auth_type, result
+
+# Inspired by https://stackoverflow.com/a/51921869
+# Reference: https://github.com/containers/image/blob/v5.6.0/docker/docker_client.go
+
+class UnsupportedAuthenticationError(NotImplementedError):
+  def __init__(self):
+    super().__init__('Only Bearer authentication supported for now')
+
+async def get_registry_auth_info(registry_host: str) -> AuthInfo:
+  auth_service = auth_realm = None
+
+  try:
+    await session.get(f'https://{registry_host}/v2/')
+    raise UnsupportedAuthenticationError  # No authentication needed
+  except HTTPError as e:
+    if e.code != 401:
+      raise
+
+    auth_type, auth_info = parse_www_authenticate_header(e.response.headers['WWW-Authenticate'])
+    if auth_type.lower() != 'bearer':
+      raise UnsupportedAuthenticationError
+
+    # Although 'service' is needed as per https://docs.docker.com/registry/spec/auth/token/,
+    # ghcr.io (GitHub container registry) does not provide it
+    auth_service = auth_info.get('service')
+    auth_realm = auth_info['realm']
+
+    return AuthInfo(auth_service, auth_realm)
+
+async def get_container_tags(info: Tuple[str, str, AuthInfo]) -> List[str]:
+  image_path, registry_host, auth_info = info
+
+  auth_params = {
+    'scope': f'repository:{image_path}:pull',
+  }
+  if auth_info.service:
+    auth_params['service'] = auth_info.service
+  res = await session.get(auth_info.realm, params=auth_params)
+  token = res.json()['token']
+
+  res = await session.get(f'https://{registry_host}/v2/{image_path}/tags/list', headers={
+    'Authorization': f'Bearer {token}',
+    'Accept': 'application/json',
+  })
+  return res.json()['tags']
+
+async def get_version(name, conf, *, cache, **kwargs):
+  image_path = conf.get('container', name)
+  registry_host = conf.get('registry', 'docker.io')
+  if registry_host == 'docker.io':
+    registry_host = 'registry-1.docker.io'
+
+  auth_info = await cache.get(registry_host, get_registry_auth_info)
+
+  key = image_path, registry_host, auth_info
+  return await cache.get(key, get_container_tags)

--- a/tests/test_android_sdk.py
+++ b/tests/test_android_sdk.py
@@ -1,6 +1,6 @@
 # MIT licensed
 # Copyright (c) 2020 lilydjwg <lilydjwg@gmail.com>, et al.
-# Copyright (c) 2017 Yen Chi Hsuan <yan12125 at gmail dot com>
+# Copyright (c) 2017 Chih-Hsuan Yen <yan12125 at gmail dot com>
 
 import pytest
 pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,0 +1,12 @@
+# MIT licensed
+# Copyright (c) 2020 Chih-Hsuan Yen <yan12125 at gmail dot com>
+
+import pytest
+pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]
+
+async def test_container(get_version):
+  assert await get_version("hello-world", {
+    "source": "container",
+    "container": "library/hello-world",
+    "include_regex": "linux",
+  }) == "linux"


### PR DESCRIPTION
Closes #59

<del>Uploaded as a draft to see if CI passes</del>

<del>This PR introduces a new dependency for decoding one of OAuth2 header. If you don't want an additional dependency, please tell me and I will try to implement the decoding. (should be less than 100 lines, hopefully)</del> Copied needed parts from Werkzeug

Tested images:
* docker.io/library/python
* docker.io/library/archlinux (for testing caching of auth info)
* registry.gitlab.com/yan12125/yan12125.gitlab.io/website
* quay.io/prometheus/node-exporter
* gcr.io/google.com/cloudsdktool/cloud-sdk
* ghcr.io/br3ndonland/inboard