### PR TITLE
repology: add support for subrepo

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -568,6 +568,11 @@ repology
 repo
   Check the version in this repo. This field is required.
 
+subrepo
+  Check the version in this subrepo. This field is optional.
+  When ommited all subrepos are queried and first entry
+  (not the highest version) is returned.
+
 Check Anitya
 ~~~~~~~~~~~~
 ::

--- a/nvchecker_source/repology.py
+++ b/nvchecker_source/repology.py
@@ -8,14 +8,22 @@ API_URL = 'https://repology.org/api/v1/project/{}'
 async def get_version(name, conf, *, cache, **kwargs):
   project = conf.get('repology') or name
   repo = conf.get('repo')
+  subrepo = conf.get('subrepo')
   if not repo:
     raise GetVersionError('repo field is required for repology source')
 
   url = API_URL.format(project)
   data = await cache.get_json(url)
 
-  versions = [pkg['version'] for pkg in data if pkg['repo'] == repo]
-  if not versions:
+  pkgs = [pkg for pkg in data if pkg['repo'] == repo]
+  if not pkgs:
     raise GetVersionError('package is not found', repo=repo)
 
+  if subrepo:
+    pkgs = [pkg for pkg in pkgs if pkg.get('subrepo') == subrepo]
+    if not pkgs:
+        raise GetVersionError('package is not found in subrepo',
+                              repo=repo, subrepo=subrepo)
+
+  versions = [pkg['version'] for pkg in pkgs]
   return versions[0]

--- a/tests/test_repology.py
+++ b/tests/test_repology.py
@@ -11,6 +11,23 @@ async def test_repology(get_version):
         "repo": "aur",
   }) == "3.62"
 
+async def test_repology_subrepo(get_version):
+  assert await get_version("asciiquarium", {
+        "source": "repology",
+        "repo": "fedora_32",
+        "subrepo": "release"
+  }) == "1.1"
+
+async def test_repology_bad_subrepo(get_version):
+  try:
+    assert await get_version("asciiquarium", {
+            "source": "repology",
+            "repo": "fedora_32",
+            "subrepo": "badsubrepo"
+    }) is None
+  except RuntimeError as e:
+    assert "package is not found in subrepo" in str(e)
+
 async def test_repology_no_repo(get_version):
   try:
     assert await get_version("ssed", {


### PR DESCRIPTION
Without this, querying latest Fedora packages is impossible because they
reside in `updates` subrepo but old `release` versions are returned.
Same thing for openSUSE.

Example config to query Fedora 32 latest packages in updates subrepo:

```
[somepackage]
source = "repology"
repo = "fedora_32"
subrepo = "updates"
```