### PR TITLE
Add a mercurial source

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -673,6 +673,19 @@ git
 
 This source returns tags and supports :ref:`list options`.
 
+Check Mercurial repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+::
+
+  source = "mercurial"
+
+This enables you to check tags of an arbitrary mercurial repository.
+
+mercurial
+  URL of the Mercurial repository.
+
+This source returns tags and supports :ref:`list options`.
+
 Check container registry
 ~~~~~~~~~~~~~~~~~~~~~~~~
 ::

--- a/nvchecker_source/mercurial.py
+++ b/nvchecker_source/mercurial.py
@@ -1,0 +1,10 @@
+# MIT licensed
+# Copyright (c) 2020 Felix Yan <felixonmars@archlinux.org>, et al.
+
+async def get_version(name, conf, *, cache, **kwargs):
+  url = conf.get('mercurial') + '/json-tags'
+
+  data = await cache.get_json(url)
+
+  version = [tag['tag'] for tag in data['tags']]
+  return version

--- a/tests/test_mercurial.py
+++ b/tests/test_mercurial.py
@@ -1,0 +1,11 @@
+# MIT licensed
+# Copyright (c) 2020 Felix Yan <felixonmars@archlinux.org>, et al.
+
+import pytest
+pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]
+
+async def test_mercurial(get_version):
+    assert await get_version("example", {
+        "source": "mercurial",
+        "mercurial": "https://www.mercurial-scm.org/repo/users/sid0/hg-git",
+    }) == "0.8.0"


### PR DESCRIPTION
This uses the json api of mercurial repositories. Verified to work on
the following hosting sites:

www.mercurial-scm.org/repo
hg.code.sf.net
hg.nginx.org
hg.mozilla.org