### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.8-alpine
+LABEL description="New version checker for software"
+ENV DEPENDENCIES libcurl wget gzip
+ENV BUILD_DEPENDENCIES curl-dev build-base
+ENV PYCURL_SSL_LIBRARY openssl
+
+COPY . /app
+RUN \
+    cd /app && \
+    apk add --no-cache --virtual .build-dependencies $BUILD_DEPENDENCIES  && \
+    apk add --no-cache --virtual .dependencies $DEPENDENCIES && \
+    python3 setup.py install && \
+    apk --purge del .build-dependencies
+
+CMD ["nvchecker"]

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -48,6 +48,24 @@ Run with one or more software version files::
 
 You normally will like to specify some "version record files"; see below.
 
+Docker
+------
+Nvchecker can be run in a Docker container without the need to install locally.
+
+To build the container::
+
+    docker build . --tag nvchecker
+
+To run the container and see available options::
+
+    docker run nvchecker nvchecker --help
+
+Because nvchecker persists version record files, you may wish to mount a volume
+for configuration and version record files. This example assumes that the
+configuration file and both version record files are location in ``/config``::
+
+    docker run -v $(pwd)/config:/config nvchecker nvchecker -c /config/nvchecker.toml
+
 JSON logging
 ~~~~~~~~~~~~
 With ``--logger=json`` or ``--logger=both``, you can get a structured logging


### PR DESCRIPTION
This PR proposes a Dockerfile that can be used to run `nvchecker` in a container, without the need for a local installation. I've proposed some limited documentation to go along with this, although I understand that some/all of this PR may be ultimately unwanted. 

Additionally, this PR turns `nvchecker_source` into a module. Attempts to run `nvchecker` after build in a clean container result in `Error: No module named 'nvchecker_source'`. Presumably `import_module` expects a proper module. 