### PR TITLE
Use packaging.version instead of pkg_resources.parse_version by default

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -203,9 +203,9 @@ exclude_regex
 
 sort_version_key
   Sort the version string using this key function. Choose between
-  ``parse_version`` and ``vercmp``. Default value is ``parse_version``.
-  ``parse_version`` use ``pkg_resources.parse_version``. ``vercmp`` use
-  ``pyalpm.vercmp``.
+  ``packaging``, ``parse_version`` and ``vercmp``. Default value is ``packaging``.
+  ``packaging`` use ``packaging.version``, ``parse_version`` use ``pkg_resources.parse_version``.
+  ``vercmp`` use ``pyalpm.vercmp``.
 
 ignored
   Version strings that are explicitly ignored, separated by whitespace. This
@@ -368,7 +368,7 @@ branch
 
 use_max_tag
   Set this to ``true`` to check for the max tag on Gitea. Will return the biggest one
-  sorted by ``pkg_resources.parse_version``. Will return the tag name instead of date.
+  sorted by ``packaging.version``. Will return the tag name instead of date.
 
 host
   Hostname for self-hosted Gitea instance.
@@ -400,7 +400,7 @@ branch
 
 use_max_tag
   Set this to ``true`` to check for the max tag on BitBucket. Will return the biggest one
-  sorted by ``pkg_resources.parse_version``. Will return the tag name instead of date.
+  sorted by ``packaging.version``. Will return the tag name instead of date.
 
 max_page
   How many pages do we search for the max tag? Default is 3. This works when
@@ -425,7 +425,7 @@ branch
 
 use_max_tag
   Set this to ``true`` to check for the max tag on GitLab. Will return the biggest one
-  sorted by ``pkg_resources.parse_version``. Will return the tag name instead of date.
+  sorted by ``packaging.version``. Will return the tag name instead of date.
 
 host
   Hostname for self-hosted GitLab instance.

--- a/nvchecker/core.py
+++ b/nvchecker/core.py
@@ -305,8 +305,8 @@ def apply_list_options(
   if not versions:
     return None
 
-  sort_version_key = sort_version_keys[
-    conf.get("sort_version_key", "parse_version")]
+  sort_version_key = sort_version_keys(
+    conf.get("sort_version_key", "packaging"))
   versions.sort(key=sort_version_key)
 
   return versions[-1]

--- a/nvchecker/sortversion.py
+++ b/nvchecker/sortversion.py
@@ -2,21 +2,22 @@
 # Copyright (c) 2013-2017 lilydjwg <lilydjwg@gmail.com>, et al.
 
 '''
-Sort versions using pkg_resource.parse_version or pyalpm.vercmp
+Sort versions using packaging.version, pkg_resource.parse_version, or pyalpm.vercmp
 '''
 
 __all__ = ["sort_version_keys"]
 
 from functools import cmp_to_key
 
-from pkg_resources import parse_version
-try:
-  import pyalpm
-  vercmp = cmp_to_key(pyalpm.vercmp)
-  vercmp_available = True
-except ImportError:
-  def vercmp(k):
-    raise NotImplementedError("Using vercmp but pyalpm can not be imported!")
-  vercmp_available = False
-
-sort_version_keys = {"parse_version": parse_version, "vercmp": vercmp}
+def sort_version_keys(method: str):
+  if method == "packaging":
+    from packaging import version
+    return version.parse
+  elif method == "parse_version":
+    from pkg_resources import parse_version
+    return parse_version
+  elif method == "vercmp":
+    import pyalpm
+    return cmp_to_key(pyalpm.vercmp)
+  else:
+    raise NotImplementedError(f"Unsupported method {method} specified!")

--- a/nvchecker/tools.py
+++ b/nvchecker/tools.py
@@ -72,9 +72,9 @@ def cmp() -> None:
   parser.add_argument('-q', '--quiet', action='store_true',
                       help="Quiet mode, output only the names.")
   parser.add_argument('-s', '--sort',
-                      choices=('parse_version', 'vercmp'), default='parse_version',
+                      choices=('packaging', 'parse_version', 'vercmp'), default='packaging',
                       help='Version compare method to backwards the arrow '
-                           '(default: parse_version)')
+                           '(default: packaging)')
   parser.add_argument('-n', '--newer', action='store_true',
                       help='Shows only the newer ones according to --sort.')
   args = parser.parse_args()
@@ -106,7 +106,7 @@ def cmp() -> None:
         arrow = "->"
         if args.sort != "none" and oldver is not None and newver is not None:
           from .sortversion import sort_version_keys
-          version = sort_version_keys[args.sort]
+          version = sort_version_keys(args.sort)
           if version(oldver) > version(newver):
             arrow = f'{c.red}<-{c.normal}'
             if args.newer:

--- a/nvchecker_source/bitbucket.py
+++ b/nvchecker_source/bitbucket.py
@@ -1,8 +1,6 @@
 # MIT licensed
 # Copyright (c) 2013-2020 lilydjwg <lilydjwg@gmail.com>, et al.
 
-from nvchecker.api import sort_version_keys
-
 # doc: https://confluence.atlassian.com/display/BITBUCKET/commits+or+commit+Resource
 BITBUCKET_URL = 'https://bitbucket.org/api/2.0/repositories/%s/commits/%s'
 BITBUCKET_MAX_TAG = 'https://bitbucket.org/api/2.0/repositories/%s/refs/tags'

--- a/tests/test_sortversion.py
+++ b/tests/test_sortversion.py
@@ -1,12 +1,20 @@
 import pytest
 
-from nvchecker.sortversion import parse_version, vercmp, vercmp_available
+from nvchecker.sortversion import sort_version_keys
 
 def test_parse_version():
+  parse_version = sort_version_keys("parse_version")
   assert parse_version("v6.0") < parse_version("6.1")
   assert parse_version("v6.0") > parse_version("v6.1-stable")
 
-@pytest.mark.skipif(not vercmp_available,
-                    reason="needs pyalpm")
+def test_packaging():
+  packaging_version = sort_version_keys("packaging")
+  assert packaging_version("v6.0") < packaging_version("6.1")
+  assert packaging_version("v6.0") > packaging_version("v6.1-stable")
+
 def test_vercmp():
+  try:
+    vercmp = sort_version_keys("vercmp")
+  except ImportError:
+    pytest.skip("needs pyalpm")
   assert vercmp("v6.0") < vercmp("v6.1-stable")


### PR DESCRIPTION
packaging.version is the new standard and should be preferred now. It
reduces startup time significantly too as pkg_resources is expensive to
import.

parse_version is only kept for compatibility here, perhaps consider
removing it in the future.