### PR TITLE
Update tests

### DIFF
--- a/tests/test_android_sdk.py
+++ b/tests/test_android_sdk.py
@@ -17,7 +17,7 @@ async def test_android_package(get_version):
         "source": "android_sdk",
         "android_sdk": "cmake;",
         "repo": "package",
-    }) == "3.6.4111459"
+    }) == "3.18.1"
 
 
 async def test_android_package_channel(get_version):
@@ -26,4 +26,4 @@ async def test_android_package_channel(get_version):
         "android_sdk": "cmake;",
         "repo": "package",
         "channel": "beta,dev,canary",
-    }) == "3.18.1"
+    }) == None

--- a/tests/test_anitya.py
+++ b/tests/test_anitya.py
@@ -9,4 +9,4 @@ async def test_anitya(get_version):
   assert await get_version("shutter", {
     "source": "anitya",
     "anitya": "fedora/shutter",
-  }) == "0.94.3"
+  }) == "0.95"

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -16,7 +16,7 @@ async def test_gitlab_blm(get_version):
     # repo with a custom main branch
     ver = await get_version("example", {
         "source": "gitlab",
-        "gitlab": "asus-linux/asus-nb-ctrl",
+        "gitlab": "asus-linux/asusctl",
     })
     assert len(ver) == 8
     assert ver.isdigit()


### PR DESCRIPTION
https://gitlab.com/asus-linux/asus-nb-ctrl redirects to https://gitlab.com/asus-linux/asusctl, while GitLab APIs seem unable to handle such cases.