### PR TITLE
Fix test_pacman in some scenarios

### DIFF
--- a/tests/test_anitya.py
+++ b/tests/test_anitya.py
@@ -9,4 +9,4 @@ async def test_anitya(get_version):
   assert await get_version("shutter", {
     "source": "anitya",
     "anitya": "fedora/shutter",
-  }) == "0.95"
+  }) == "0.96"

--- a/tests/test_pacman.py
+++ b/tests/test_pacman.py
@@ -1,11 +1,14 @@
 # MIT licensed
 # Copyright (c) 2013-2020 lilydjwg <lilydjwg@gmail.com>, et al.
 
+import pathlib
 import shutil
 import pytest
 pytestmark = [pytest.mark.asyncio,
               pytest.mark.skipif(shutil.which("pacman") is None,
-                                 reason="requires pacman command")]
+                                 reason="requires pacman command"),
+              pytest.mark.skipif(not pathlib.Path("/var/lib/pacman/sync/core.db").exists(),
+                                 reason="requires synced pacman databases")]
 
 async def test_pacman(get_version):
     assert await get_version("ipw2100-fw", {


### PR DESCRIPTION
For example, on reproducible.archlinux.org, apparently pacman databases
are not synced before building synced before building packages, and thus
packages cannot be found. From https://reproducible.archlinux.org/api/v0/builds/110565/log,
```
=================================== FAILURES ===================================
_________________________________ test_pacman __________________________________

get_version = <function get_version.<locals>.__call__ at 0x7f2fa5ed1310>

    async def test_pacman(get_version):
>       assert await get_version("ipw2100-fw", {
            "source": "pacman",
        }) == "1.3-10"

tests/test_pacman.py:11:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/conftest.py:46: in __call__
    newvers = await run(entries)
tests/conftest.py:40: in run
    return await main.run(result_coro, runner_coro)
nvchecker/__main__.py:92: in run
    return await result_fu
nvchecker/core.py:361: in process_result
    r1 = _process_result(r)
nvchecker/core.py:322: in _process_result
    logger.error(version.msg, **kw)
/usr/lib/python3.9/site-packages/structlog/_log_levels.py:118: in meth
    return self._proxy_to_logger(name, event, **kw)
/usr/lib/python3.9/site-packages/structlog/_base.py:198: in _proxy_to_logger
    args, kw = self._process_event(method_name, event, event_kw)
/usr/lib/python3.9/site-packages/structlog/_base.py:155: in _process_event
    event_dict = proc(self._logger, method_name, event_dict)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

logger = <PrintLogger(file=<_io.TextIOWrapper name="<_io.FileIO name=6 mode='rb+' closefd=True>" mode='r+' encoding='utf-8'>)>
method_name = 'error'
event_dict = {'cmd': "LANG=C pacman -Si ipw2100-fw | grep -F Version | awk '{print $3}' | head -n 1", 'error': "warning: database f...r: package 'ipw2100-fw' was not found", 'event': 'command exited without output', 'logger_name': 'nvchecker.core', ...}

    def proc(logger, method_name, event_dict):
      if method_name in ('warning', 'error'):
        if 'exc_info' in event_dict:
          raise event_dict['exc_info']
        if not event_dict['event'].startswith(('rate limited', 'no-result')):
>         raise RuntimeError(event_dict['event'])
E         RuntimeError: command exited without output

tests/conftest.py:85: RuntimeError
----------------------------- Captured stdout call -----------------------------
running cmd
__________________________ test_pacman_strip_release ___________________________

get_version = <function get_version.<locals>.__call__ at 0x7f2fa5ed1310>

    async def test_pacman_strip_release(get_version):
>       assert await get_version("ipw2100-fw", {
            "source": "pacman",
            "strip_release": 1,
        }) == "1.3"

tests/test_pacman.py:16:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/conftest.py:46: in __call__
    newvers = await run(entries)
tests/conftest.py:40: in run
    return await main.run(result_coro, runner_coro)
nvchecker/__main__.py:92: in run
    return await result_fu
nvchecker/core.py:361: in process_result
    r1 = _process_result(r)
nvchecker/core.py:322: in _process_result
    logger.error(version.msg, **kw)
/usr/lib/python3.9/site-packages/structlog/_log_levels.py:118: in meth
    return self._proxy_to_logger(name, event, **kw)
/usr/lib/python3.9/site-packages/structlog/_base.py:198: in _proxy_to_logger
    args, kw = self._process_event(method_name, event, event_kw)
/usr/lib/python3.9/site-packages/structlog/_base.py:155: in _process_event
    event_dict = proc(self._logger, method_name, event_dict)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

logger = <PrintLogger(file=<_io.TextIOWrapper name="<_io.FileIO name=6 mode='rb+' closefd=True>" mode='r+' encoding='utf-8'>)>
method_name = 'error'
event_dict = {'cmd': "LANG=C pacman -Si ipw2100-fw | grep -F Version | awk '{print $3}' | head -n 1", 'error': "warning: database f...r: package 'ipw2100-fw' was not found", 'event': 'command exited without output', 'logger_name': 'nvchecker.core', ...}

    def proc(logger, method_name, event_dict):
      if method_name in ('warning', 'error'):
        if 'exc_info' in event_dict:
          raise event_dict['exc_info']
        if not event_dict['event'].startswith(('rate limited', 'no-result')):
>         raise RuntimeError(event_dict['event'])
E         RuntimeError: command exited without output

tests/conftest.py:85: RuntimeError
----------------------------- Captured stdout call -----------------------------
running cmd
```

An alternative approach is download pacman databases to a temporary location like [what lilac does](https://github.com/archlinuxcn/lilac/blob/b21f5c74b037b3a86546d013200cd6dca1b6614a/lilac2/pkgbuild.py#L68). I'm too lazy to implement it just for some unusal environments :)