### PR TITLE
Docs: add sample keyfile.toml

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -136,9 +136,18 @@ http_timeout
   Time in seconds to wait for HTTP requests. Default: 20.
 
 keyfile
-  Specify an ini config file containing key (token) information. This file
+  Specify a toml config file containing key (token) information. This file
   should contain a ``keys`` table, mapping key names to key values. See
   specific source for the key name(s) to use.
+
+  Sample ``keyfile.toml``:
+
+  ```toml
+  [keys]
+  # https://github.com/settings/tokens
+  # scope: repo -> public_repo
+  github = "ghp_<stripped>"
+  ```
 
 Global Options
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
In general, I think docs are missing a quickstart section that would cover 80% of use cases and would help people actually *not* read the docs :laughing: 

---

From 

> Specify an ini config file containing key (token) information. This file should contain a `keys` table, mapping key names to key values.

and just an example I'd surely would've picked up the latter, it's all I need to get started.

---

I had to guess `ini` here in the docs was an inaccuracy and experimented with `nvcchecker` / `nvcmp` to find keyfile to please the tool. Then I also saw encrypted `keyfile.toml.enc` in the repo :smile: 