### PR TITLE
Cleanup dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
   zip_safe = True,
 
   packages = find_namespace_packages(exclude=['tests', 'build*', 'docs*']),
-  install_requires = ['setuptools', 'packaging', 'toml', 'structlog', 'appdirs', 'tornado>=6', 'pycurl'],
+  install_requires = ['packaging', 'toml', 'structlog', 'appdirs', 'tornado>=6', 'pycurl'],
   extras_require = {
     'vercmp': ['pyalpm'],
   },


### PR DESCRIPTION
* setuptools is no longer needed after 606b3f65fb4426920096edd727e14f24b51d30ba

By the way, maybe `packaging` can also be moved from `install_requires` to `extras_require` as that library is only needed by the pypi source now.