### PR TITLE
Update tests

### DIFF
--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -15,5 +15,5 @@ async def test_container_paging(get_version):
   assert await get_version("prometheus-operator", {
     "source": "container",
     "registry": "quay.io",
-    "container": "prometheus-operator/prometheus-operator",
-  }) == "v0.49.0"
+    "container": "redhattraining/hello-world-nginx",
+  }) == "v1.0"

--- a/tests/test_openvsx.py
+++ b/tests/test_openvsx.py
@@ -7,4 +7,4 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]
 async def test_openvsx(get_version):
     assert await get_version("usernamehw.indent-one-space", {
         "source": "openvsx",
-    }) == "0.2.6"
+    }) == "0.2.7"

--- a/tests/test_vsmarketplace.py
+++ b/tests/test_vsmarketplace.py
@@ -7,4 +7,4 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]
 async def test_vsmarketplace(get_version):
     assert await get_version("usernamehw.indent-one-space", {
         "source": "vsmarketplace",
-    }) == "0.2.6"
+    }) == "0.2.8"


### PR DESCRIPTION
* Use a seemingly never updated container for testing container
  registries other than docker.io
* Update versions for openvsx and vsmarketplace

PS. I'm not sure why the same package has different versions on openvsx and vsmarketplace. Maybe @Th3Whit3Wolf has some ideas? (ref: #195)