### PR TITLE
regex: make sure regex fails if nothing is found

### DIFF
--- a/nvchecker_source/regex.py
+++ b/nvchecker_source/regex.py
@@ -22,9 +22,7 @@ async def get_version_impl(info):
 
   res = await session.get(conf['url'])
   body = res.body.decode(encoding)
-  try:
-    version = regex.findall(body)
-  except ValueError:
-    if not conf.get('missing_ok', False):
-      raise GetVersionError('version string not found.')
-  return version
+  versions = regex.findall(body)
+  if not versions and not conf.get('missing_ok', False):
+    raise GetVersionError('version string not found.')
+  return versions

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -43,6 +43,14 @@ async def test_missing_ok(get_version, httpbin):
         "missing_ok": True,
     }) is None
 
+async def test_missing(get_version, httpbin):
+    with pytest.raises(RuntimeError):
+      await get_version("example", {
+          "source": "regex",
+          "url": httpbin.url + "/base64/" + base64_encode("something not there"),
+          "regex": "foobar",
+      })
+
 async def test_regex_with_tokenBasic(get_version, httpbin):
     assert await get_version("example", {
         "source": "regex",


### PR DESCRIPTION
This is a regression since 2019 [1].
Before that commit, `max()` raises `ValuError` if `re.findall` returns an
empty list. After that commit, regex fails silently if nothing is found.

[1] https://github.com/lilydjwg/nvchecker/commit/789731729472824e79e519c033a432a35cf402b2#diff-fd40f1295f9ddece86df8d2c385ddb02bd4e2a10cd20bd9a95306d3d35a9b601

Noticed this as https://github.com/archlinuxcn/repo/tree/master/archlinuxcn/android-ndk is not automatically updated and no errors are reported.