### PR TITLE
Bitbucket: Add support for queries and sorting

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -467,11 +467,27 @@ use_max_tag
   Set this to ``true`` to check for the max tag on BitBucket. Will return the biggest one
   sorted by old ``pkg_resources.parse_version``. Will return the tag name instead of date.
 
+use_sorted_tags
+    If ``true``, tags are queried and sorted according to the ``query`` and
+    ``sort`` keys. Will return the tag name instead of the date.
+
+query
+    A query string use to filter tags when ``use_sorted_tags`` is set (see
+    `here <https://developer.atlassian.com/cloud/bitbucket/rest/intro/#querying>`__
+    for examples). The string does not need to be escaped.
+
+sort
+    A field used to sort the tags when ``use_sorted_tags`` is set (see
+    `here <https://developer.atlassian.com/cloud/bitbucket/rest/intro/#filtering>`__
+    for examples). Defaults to ``-target.date`` (sorts tags in descending order
+    by date).
+
 max_page
   How many pages do we search for the max tag? Default is 3. This works when
   ``use_max_tag`` is set.
 
-This source supports :ref:`list options` when ``use_max_tag`` is set.
+This source supports :ref:`list options` when ``use_max_tag`` or
+``use_sorted_tags`` is set.
 
 Check GitLab
 ~~~~~~~~~~~~
@@ -848,7 +864,7 @@ Check `Open Vsx <https://open-vsx.org/>`_ for updates.
 
 openvsx
   The extension's Unique Identifier on open-vsx.org, e.g. ``ritwickdey.LiveServer``.
-  
+
 Check Visual Studio Code Marketplace
 ~~~~~~~~~~~~~~~
 ::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -472,7 +472,7 @@ use_sorted_tags
     ``sort`` keys. Will return the tag name instead of the date.
 
 query
-    A query string use to filter tags when ``use_sorted_tags`` is set (see
+    A query string use to filter tags when ``use_sorted_tags`` set (see
     `here <https://developer.atlassian.com/cloud/bitbucket/rest/intro/#querying>`__
     for examples). The string does not need to be escaped.
 

--- a/nvchecker_source/bitbucket.py
+++ b/nvchecker_source/bitbucket.py
@@ -5,7 +5,7 @@ from nvchecker.api import sort_version_keys
 
 # doc: https://confluence.atlassian.com/display/BITBUCKET/commits+or+commit+Resource
 BITBUCKET_URL = 'https://bitbucket.org/api/2.0/repositories/%s/commits/%s'
-BITBUCKET_MAX_TAG = 'https://bitbucket.org/api/2.0/repositories/%s/refs/tags'
+BITBUCKET_MAX_TAG = 'https://bitbucket.org/api/2.0/repositories/%s/refs/tags?sort=-target.date'
 
 async def get_version(name, conf, *, cache, **kwargs):
   repo = conf['bitbucket']

--- a/nvchecker_source/bitbucket.py
+++ b/nvchecker_source/bitbucket.py
@@ -1,12 +1,19 @@
 # MIT licensed
 # Copyright (c) 2013-2020 lilydjwg <lilydjwg@gmail.com>, et al.
 
+from typing import Any, List
+from nvchecker.api import VersionResult, Entry, AsyncCache
+
 # doc: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commits/#api-repositories-workspace-repo-slug-commits-get
 BITBUCKET_URL = 'https://bitbucket.org/api/2.0/repositories/%s/commits/%s'
 # doc: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-refs/#api-repositories-workspace-repo-slug-refs-tags-get
 BITBUCKET_MAX_TAG = 'https://bitbucket.org/api/2.0/repositories/%s/refs/tags?sort=-target.date'
 
-async def get_version(name, conf, *, cache, **kwargs):
+async def get_version(
+  name: str, conf: Entry, *,
+  cache: AsyncCache,
+  **kwargs: Any,
+) -> VersionResult:
   repo = conf['bitbucket']
   br = conf.get('branch', '')
   use_max_tag = conf.get('use_max_tag', False)
@@ -26,7 +33,11 @@ async def get_version(name, conf, *, cache, **kwargs):
     version = data['values'][0]['date'].split('T', 1)[0].replace('-', '')
   return version
 
-async def _get_tags(url, *, max_page, cache):
+async def _get_tags(
+  url: str, *,
+  max_page: int,
+  cache: AsyncCache,
+) -> List[str]:
   ret = []
 
   for _ in range(max_page):

--- a/nvchecker_source/bitbucket.py
+++ b/nvchecker_source/bitbucket.py
@@ -1,10 +1,9 @@
 # MIT licensed
 # Copyright (c) 2013-2020 lilydjwg <lilydjwg@gmail.com>, et al.
 
-from nvchecker.api import sort_version_keys
-
-# doc: https://confluence.atlassian.com/display/BITBUCKET/commits+or+commit+Resource
+# doc: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commits/#api-repositories-workspace-repo-slug-commits-get
 BITBUCKET_URL = 'https://bitbucket.org/api/2.0/repositories/%s/commits/%s'
+# doc: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-refs/#api-repositories-workspace-repo-slug-refs-tags-get
 BITBUCKET_MAX_TAG = 'https://bitbucket.org/api/2.0/repositories/%s/refs/tags?sort=-target.date'
 
 async def get_version(name, conf, *, cache, **kwargs):

--- a/nvchecker_source/bitbucket.py
+++ b/nvchecker_source/bitbucket.py
@@ -2,12 +2,14 @@
 # Copyright (c) 2013-2020 lilydjwg <lilydjwg@gmail.com>, et al.
 
 from typing import Any, List
+from urllib.parse import urlencode
+
 from nvchecker.api import VersionResult, Entry, AsyncCache
 
 # doc: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commits/#api-repositories-workspace-repo-slug-commits-get
 BITBUCKET_URL = 'https://bitbucket.org/api/2.0/repositories/%s/commits/%s'
 # doc: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-refs/#api-repositories-workspace-repo-slug-refs-tags-get
-BITBUCKET_MAX_TAG = 'https://bitbucket.org/api/2.0/repositories/%s/refs/tags?sort=-target.date'
+BITBUCKET_MAX_TAG = 'https://bitbucket.org/api/2.0/repositories/%s/refs/tags'
 
 async def get_version(
   name: str, conf: Entry, *,
@@ -17,8 +19,19 @@ async def get_version(
   repo = conf['bitbucket']
   br = conf.get('branch', '')
   use_max_tag = conf.get('use_max_tag', False)
+  use_sorted_tags = conf.get('use_sorted_tags', False)
 
-  if use_max_tag:
+  if use_sorted_tags:
+    url = BITBUCKET_MAX_TAG % repo
+
+    parameters = {'sort': conf.get('sort', '-target.date')}
+    if 'query' in conf:
+        parameters['q'] = conf['query']
+
+    url += '?' + urlencode(parameters)
+    data = await _get_tags(url, max_page=1, cache=cache)
+
+  elif use_max_tag:
     url = BITBUCKET_MAX_TAG % repo
     max_page = conf.get('max_page', 3)
     data = await _get_tags(url, max_page=max_page, cache=cache)
@@ -27,7 +40,7 @@ async def get_version(
     url = BITBUCKET_URL % (repo, br)
     data = await cache.get_json(url)
 
-  if use_max_tag:
+  if use_max_tag or use_sorted_tags:
     version = data
   else:
     version = data['values'][0]['date'].split('T', 1)[0].replace('-', '')

--- a/tests/test_bitbucket.py
+++ b/tests/test_bitbucket.py
@@ -24,3 +24,25 @@ async def test_bitbucket_max_tag_with_ignored(get_version):
         "use_max_tag": True,
         "ignored": "1.6.0 1.7.0",
     }) == "v1.5"
+
+async def test_bitbucket_sorted_tags(get_version):
+    assert await get_version("example", {
+        "source": "bitbucket",
+        "bitbucket": "prawee/git-tag",
+        "use_sorted_tags": True,
+    }) == "1.7.0"
+
+    assert await get_version("example", {
+        "source": "bitbucket",
+        "bitbucket": "prawee/git-tag",
+        "use_sorted_tags": True,
+        "query": 'name~"v"',
+    }) == "v1.5"
+
+    assert await get_version("example", {
+        "source": "bitbucket",
+        "bitbucket": "berkeleylab/gasnet",
+        "use_sorted_tags": True,
+        "query": 'name~"CVS/BERKELEY_UPC" AND name!~"rc"',
+        "prefix": "CVS/BERKELEY_UPC_",
+    }) == "2_18_0"


### PR DESCRIPTION
Make better use of the bitbucket API to sort tags:

* use `q="my_query"` to narrow down the results. This does not support fancy regex queries, just `contains` and comparisons.
* use `sort=field` to sort the results by the given field.
* use `fields=values.name,next` to only return relevant data.