### PR TITLE
Fix asyncio.run problem

### DIFF
--- a/nvchecker/__main__.py
+++ b/nvchecker/__main__.py
@@ -78,7 +78,7 @@ def main() -> None:
   result_coro = core.process_result(oldvers, result_q, entry_waiter)
   runner_coro = core.run_tasks(futures)
 
-  newvers, has_failures = asyncio.run(run(result_coro, runner_coro))
+  newvers, has_failures = asyncio.get_event_loop().run_until_complete(run(result_coro, runner_coro))
 
   if options.ver_files is not None:
     core.write_verfile(options.ver_files[1], newvers)


### PR DESCRIPTION
nvchecker was giving me the
    "Task got Future <Future pending> attached to a different loop"
message mentioned at
    https://github.com/awestlake87/pyo3-asyncio/issues/19
so I applied the same change and nvchecker worked again.

Environment: Python 3.9 on Debian Bullseye