### PR TITLE
Add CRAN support

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -587,6 +587,17 @@ Check `MetaCPAN <https://metacpan.org/>`_ for updates.
 cpan
   The name used on CPAN, e.g. ``YAML``.
 
+Check CRAN
+~~~~~~~~~~
+::
+
+  source = "cran"
+
+Check `CRAN <https://cran.r-project.org/web/packages/>`_ for updates.
+
+cran
+  The name used on CRAN, e.g. ``xml2``.
+
 Check Packagist
 ~~~~~~~~~~~~~~~
 ::

--- a/nvchecker_source/cran.py
+++ b/nvchecker_source/cran.py
@@ -1,0 +1,26 @@
+# MIT licensed
+# Copyright (c) 2022 Pekka Ristola <pekkarr [at] protonmail [dot] com>, et al.
+
+from nvchecker.api import session, GetVersionError
+
+CRAN_URL = 'https://cran.r-project.org/package=%s/DESCRIPTION'
+VERSION_FIELD = 'Version: '
+
+async def request(pkg):
+  url = CRAN_URL % pkg
+  res = await session.get(url)
+  return res.body.decode('utf-8', errors='ignore')
+
+async def get_version(name, conf, *, cache, **kwargs):
+  package = conf.get('cran', name)
+
+  desc = await cache.get(package, request)
+
+  for line in desc.splitlines():
+    if line.startswith(VERSION_FIELD):
+      version = line[len(VERSION_FIELD):]
+      break
+  else:
+    raise GetVersionError('Invalid DESCRIPTION file')
+
+  return version

--- a/tests/test_cran.py
+++ b/tests/test_cran.py
@@ -1,0 +1,10 @@
+# MIT licensed
+# Copyright (c) 2022 Pekka Ristola <pekkarr [at] protonmail [dot] com>, et al.
+
+import pytest
+pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]
+
+async def test_cran(get_version):
+    assert await get_version("xml2", {
+        "source": "cran",
+    }) == "1.3.3"


### PR DESCRIPTION
Add CRAN support using per-package [DESCRIPTION](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file) files unlike the previous pr (#184) that downloaded the entire database.