### PR TITLE
alpm source: support checking packages from multiple repos

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -859,9 +859,11 @@ Check package updates in a local ALPM database.
 alpm
   Name of the package.
 
-repo / repos
-  Name of the package repository in which the package resides. If not provided, nvchecker will search ``repos``, if ``repos`` is not provided either, ``core``, ``extra``, ``community`` and ``multilib`` will be used, in that order.
+repo
+  Name of the package repository in which the package resides. If not provided, nvchecker will use ``repos`` value, see below.
 
+repos
+  An array of possible repositories in which the package may reside in, nvchecker will use the first repository which contains the package. If not provided, ``core``, ``extra``, ``community`` and ``multilib`` will be used, in that order.
 
 dbpath
   Path to the ALPM database directory. Default: ``/var/lib/pacman``. You need to update the database yourself.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -859,8 +859,9 @@ Check package updates in a local ALPM database.
 alpm
   Name of the package.
 
-repo
-  Name of the package repository in which the package resides. If not provided, nvchecker will search ``core``, ``extra``, ``community`` and ``multilib``, in that order.
+repo / repos
+  Name of the package repository in which the package resides. If not provided, nvchecker will search ``repos``, if ``repos`` is not provided either, ``core``, ``extra``, ``community`` and ``multilib`` will be used, in that order.
+
 
 dbpath
   Path to the ALPM database directory. Default: ``/var/lib/pacman``. You need to update the database yourself.

--- a/nvchecker_source/alpm.py
+++ b/nvchecker_source/alpm.py
@@ -20,7 +20,7 @@ async def get_version(name, conf, *, cache, **kwargs):
 
   repo = conf.get('repo')
   if repo is None:
-    repos = ['core', 'extra', 'community', 'multilib']
+    repos = conf.get('repos') or ['core', 'extra', 'community', 'multilib']
   else:
     repos = [repo]
 


### PR DESCRIPTION
it's the case where the exact repository of a package is unknown (e.g. `gcc` in either `testing` or `core`)

I'm not familiar with those packaging steps, feel free to suggest any better ideas.