### PR TITLE
Port from deprecated appdirs to platformdirs

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -18,7 +18,7 @@ jobs:
           ${{ runner.os }}-${{ env.cache-name }}-
           ${{ runner.os }}-cache-pip-
     - name: Install deps
-      run: pip3 install -U tornado pytest pytest-asyncio pytest-httpbin flaky structlog tomli aiohttp httpx mypy awesomeversion
+      run: pip3 install -U tornado pytest pytest-asyncio pytest-httpbin flaky structlog tomli platformdirs aiohttp httpx mypy awesomeversion
     - name: Run mypy for --install-types
       run: PATH=$HOME/.local/bin:$PATH mypy --namespace-packages --explicit-package-bases nvchecker nvchecker_source tests
       continue-on-error: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,7 @@ jobs:
         sudo apt install -y libcurl4-openssl-dev
     # werkzeug is pinned for httpbin compatibility https://github.com/postmanlabs/httpbin/issues/673
     - name: Install Python deps
-      run: pip install -U ${{ matrix.deps }} pytest pytest-asyncio pytest-httpbin flaky structlog tomli appdirs lxml 'werkzeug<2.1' awesomeversion
+      run: pip install -U ${{ matrix.deps }} pytest pytest-asyncio pytest-httpbin flaky structlog tomli platformdirs lxml 'werkzeug<2.1' awesomeversion
     - name: Decrypt keys
       env:
         KEY: ${{ secrets.KEY }}

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ This is the version 2.0 branch. For the old version 1.x, please switch to the ``
 Dependency
 ----------
 - Python 3.7+
-- Python library: structlog, tomli, appdirs
+- Python library: structlog, tomli, platformdirs
 - One of these Python library combinations (ordered by preference):
 
   * tornado + pycurl

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 tomli
 structlog
-appdirs
+platformdirs
 tornado>=6
 sphinx>=3.2
 # <5 has strange bottom margins for p, and no list indicators

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -18,7 +18,7 @@ This is the version 2.0 branch. For the old version 1.x, please switch to the ``
 Dependency
 ----------
 - Python 3.7+
-- Python library: structlog, tomli, appdirs
+- Python library: structlog, tomli, platformdirs
 - One of these Python library combinations (ordered by preference):
 
   * tornado + pycurl

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,8 +18,5 @@ ignore_missing_imports = True
 [mypy-pytest_httpbin]
 ignore_missing_imports = True
 
-[mypy-appdirs]
-ignore_missing_imports = True
-
 [mypy-lxml]
 ignore_missing_imports = True

--- a/nvchecker/core.py
+++ b/nvchecker/core.py
@@ -22,7 +22,7 @@ import json
 
 import structlog
 import tomli
-import appdirs
+import platformdirs
 
 from .lib import nicelogger
 from . import slogconf
@@ -40,7 +40,7 @@ from . import httpclient
 logger = structlog.get_logger(logger_name=__name__)
 
 def get_default_config() -> str:
-  confdir = appdirs.user_config_dir(appname='nvchecker')
+  confdir = platformdirs.user_config_dir(appname='nvchecker')
   file = os.path.join(confdir, 'nvchecker.toml')
   return file
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
   setuptools; python_version<"3.8"
   tomli
   structlog
-  appdirs
+  platformdirs
   tornado>=6
   pycurl
 scripts =


### PR DESCRIPTION
This ports to [platformdirs](https://pypi.org/project/platformdirs/), which seems to be the maintained version of `appdirs` these days. It should be backwards compatible in most cases.

The port is pretty straightforward, so just need to decide if the dependency change is worth it!