### PR TITLE
Fix test_alpm in Arch chroots

### DIFF
--- a/tests/test_alpm.py
+++ b/tests/test_alpm.py
@@ -30,6 +30,7 @@ def setup_module(module):
       'pkgrel=4\n'
       'arch=(any)\n'
       'provides=("test-provides=5.6-7" "test-provides-unversioned")\n'
+      'options=(!debug)\n'
     )
   subprocess.check_call(['makepkg', '--nosign'], cwd=pkg_path)
   pkg_file = subprocess.check_output(['makepkg', '--packagelist'], cwd=pkg_path, text=True).strip()


### PR DESCRIPTION
Arch chroots with recent devtools has options=(debug) by default, and thus test_alpm fails:
```
_________________________ ERROR at setup of test_alpm __________________________

module = <module 'tests.test_alpm' from '/build/nvchecker/src/nvchecker/tests/test_alpm.py'>

    def setup_module(module):
      global temp_dir, db_path
      temp_dir = tempfile.TemporaryDirectory()
      temp_path = pathlib.Path(temp_dir.name)
      pkg_path = temp_path / 'test-pkg'
      pkg_path.mkdir()
      with (pkg_path / 'PKGBUILD').open('w') as f:
        f.write(
          'pkgname=test-pkg\n'
          'pkgver=1.2.3\n'
          'pkgrel=4\n'
          'arch=(any)\n'
          'provides=("test-provides=5.6-7" "test-provides-unversioned")\n'
        )
      subprocess.check_call(['makepkg', '--nosign'], cwd=pkg_path)
      pkg_file = subprocess.check_output(['makepkg', '--packagelist'], cwd=pkg_path, text=True).strip()
      db_path = pkg_path / 'test-db'
      db_path.mkdir()
      repo_path = db_path / 'sync'
      repo_path.mkdir()
>     subprocess.check_call([
        'repo-add',
        repo_path / 'test-repo.db.tar.gz',
        pkg_path / pkg_file
      ])

tests/test_alpm.py:40:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

popenargs = (['repo-add', PosixPath('/tmp/tmp2kl26h_y/test-pkg/test-db/sync/test-repo.db.tar.gz'), PosixPath('/pkgdest/test-pkg-1.2.3-4-any.pkg.tar.zst\n/pkgdest/test-pkg-debug-1.2.3-4-any.pkg.tar.zst')],)
kwargs = {}, retcode = 1
cmd = ['repo-add', PosixPath('/tmp/tmp2kl26h_y/test-pkg/test-db/sync/test-repo.db.tar.gz'), PosixPath('/pkgdest/test-pkg-1.2.3-4-any.pkg.tar.zst\n/pkgdest/test-pkg-debug-1.2.3-4-any.pkg.tar.zst')]

    def check_call(*popenargs, **kwargs):
        """Run command with arguments.  Wait for command to complete.  If
        the exit code was zero then return, otherwise raise
        CalledProcessError.  The CalledProcessError object will have the
        return code in the returncode attribute.

        The arguments are the same as for the call function.  Example:

        check_call(["ls", "-l"])
        """
        retcode = call(*popenargs, **kwargs)
        if retcode:
            cmd = kwargs.get("args")
            if cmd is None:
                cmd = popenargs[0]
>           raise CalledProcessError(retcode, cmd)
E           subprocess.CalledProcessError: Command '['repo-add', PosixPath('/tmp/tmp2kl26h_y/test-pkg/test-db/sync/test-repo.db.tar.gz'), PosixPath('/pkgdest/test-pkg-1.2.3-4-any.pkg.tar.zst\n/pkgdest/test-pkg-debug-1.2.3-4-any.pkg.tar.zst')]' returned non-zero exit status 1.

/usr/lib/python3.10/subprocess.py:369: CalledProcessError
---------------------------- Captured stdout setup -----------------------------
==> Making package: test-pkg 1.2.3-4 (Fri Apr  7 11:53:43 2023)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
==> Extracting sources...
==> Entering fakeroot environment...
==> Tidying install...
  -> Removing libtool files...
  -> Purging unwanted files...
  -> Removing static library files...
  -> Stripping unneeded symbols from binaries and libraries...
  -> Compressing man and info pages...
==> Checking for packaging issues...
==> Creating package "test-pkg"...
  -> Generating .PKGINFO file...
  -> Generating .BUILDINFO file...
  -> Generating .MTREE file...
  -> Compressing package...
==> Leaving fakeroot environment.
==> Finished making: test-pkg 1.2.3-4 (Fri Apr  7 11:53:44 2023)
==> No packages modified, nothing to do.
---------------------------- Captured stderr setup -----------------------------
==> ERROR: File '/pkgdest/test-pkg-1.2.3-4-any.pkg.tar.zst
/pkgdest/test-pkg-debug-1.2.3-4-any.pkg.tar.zst' not found.
```