### PR TITLE
Remove usage of deprecared sre_constants

### DIFF
--- a/nvchecker_source/httpheader.py
+++ b/nvchecker_source/httpheader.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021 lilydjwg <lilydjwg@gmail.com>, et al.
 
 import re
-import sre_constants
 
 from nvchecker.api import session, GetVersionError
 
@@ -19,7 +18,7 @@ async def get_version_impl(info):
 
   try:
     regex = re.compile(conf['regex'])
-  except sre_constants.error as e:
+  except re.error as e:
     raise GetVersionError('bad regex', exc_info=e)
 
   res = await session.request(

--- a/nvchecker_source/regex.py
+++ b/nvchecker_source/regex.py
@@ -2,14 +2,13 @@
 # Copyright (c) 2013-2020 lilydjwg <lilydjwg@gmail.com>, et al.
 
 import re
-import sre_constants
 
 from nvchecker.api import session, GetVersionError
 
 async def get_version(name, conf, *, cache, **kwargs):
   try:
     regex = re.compile(conf['regex'])
-  except sre_constants.error as e:
+  except re.error as e:
     raise GetVersionError('bad regex', exc_info=e)
   if regex.groups > 1:
     raise GetVersionError('multi-group regex')

--- a/tests/test_cran.py
+++ b/tests/test_cran.py
@@ -7,4 +7,4 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]
 async def test_cran(get_version):
     assert await get_version("xml2", {
         "source": "cran",
-    }) == "1.3.3"
+    }) == "1.3.4"


### PR DESCRIPTION
Python 3.11 deprecated `sre_constants` and mostly imports from `re` now:
https://github.com/python/cpython/blob/3.11/Lib/sre_constants.py

This ports to `re.error` instead, which should be equivalent.