### PR TITLE
Use tomllib on Python 3.11+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ This is the version 2.0 branch. For the old version 1.x, please switch to the ``
 Dependency
 ----------
 - Python 3.7+
-- Python library: structlog, tomli, platformdirs
+- Python library: structlog, platformdirs, tomli (on Python < 3.11)
 - One of these Python library combinations (ordered by preference):
 
   * tornado + pycurl

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -18,7 +18,7 @@ This is the version 2.0 branch. For the old version 1.x, please switch to the ``
 Dependency
 ----------
 - Python 3.7+
-- Python library: structlog, tomli, platformdirs
+- Python library: structlog, platformdirs, tomli (on Python < 3.11)
 - One of these Python library combinations (ordered by preference):
 
   * tornado + pycurl

--- a/nvchecker/core.py
+++ b/nvchecker/core.py
@@ -21,7 +21,12 @@ import contextvars
 import json
 
 import structlog
-import tomli
+
+try:
+  import tomllib
+except ModuleNotFoundError:
+  import tomli as tomllib
+
 import platformdirs
 
 from .lib import nicelogger
@@ -157,8 +162,8 @@ def load_file(
 ) -> Tuple[Entries, Options]:
   try:
     with open(file, 'rb') as f:
-      config = tomli.load(f)
-  except (OSError, tomli.TOMLDecodeError) as e:
+      config = tomllib.load(f)
+  except (OSError, tomllib.TOMLDecodeError) as e:
     raise FileLoadError('version configuration file', file, e)
 
   ver_files: Optional[Tuple[Path, Path]] = None

--- a/nvchecker/util.py
+++ b/nvchecker/util.py
@@ -14,7 +14,11 @@ from pathlib import Path
 import contextvars
 import abc
 
-import tomli
+try:
+  import tomllib
+except ModuleNotFoundError:
+  import tomli as tomllib
+
 import structlog
 
 from .httpclient import session
@@ -56,8 +60,8 @@ class KeyManager:
     if file is not None:
       try:
         with file.open('rb') as f:
-          keys = tomli.load(f)['keys']
-      except (OSError, tomli.TOMLDecodeError) as e:
+          keys = tomllib.load(f)['keys']
+      except (OSError, tomllib.TOMLDecodeError) as e:
         raise FileLoadError('keyfile', str(file), e)
     else:
       keys = {}

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ zip_safe = True
 packages = find_namespace:
 install_requires =
   setuptools; python_version<"3.8"
-  tomli
+  tomli; python_version<"3.11"
   structlog
   platformdirs
   tornado>=6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,11 @@ import structlog
 import os
 from pathlib import Path
 
-import tomli
+try:
+  import tomllib
+except ModuleNotFoundError:
+  import tomli as tomllib
+
 import pytest
 import pytest_asyncio
 
@@ -54,7 +58,7 @@ async def get_version():
 @pytest_asyncio.fixture(scope="module")
 async def run_str():
   async def __call__(str):
-    entries = tomli.loads(str)
+    entries = tomllib.loads(str)
     newvers = await run(entries)
     return newvers.popitem()[1]
 
@@ -63,7 +67,7 @@ async def run_str():
 @pytest_asyncio.fixture(scope="module")
 async def run_str_multi():
   async def __call__(str):
-    entries = tomli.loads(str)
+    entries = tomllib.loads(str)
     newvers = await run(entries)
     return newvers
 


### PR DESCRIPTION
Fallback to tomli for compatibility with older Python.