### PR TITLE
tests: bump android-sdk-cmake and xml2 version

### DIFF
--- a/tests/test_android_sdk.py
+++ b/tests/test_android_sdk.py
@@ -26,7 +26,7 @@ async def test_android_package_channel(get_version):
         "android_sdk": "ndk;",
         "repo": "package",
         "channel": "beta,dev,canary",
-    }) == "25.0.8528842"
+    }) == "26.0.10404224"
 
 async def test_android_list(get_version):
     assert await get_version("android-sdk-cmake-older", {

--- a/tests/test_cran.py
+++ b/tests/test_cran.py
@@ -7,4 +7,4 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]
 async def test_cran(get_version):
     assert await get_version("xml2", {
         "source": "cran",
-    }) == "1.3.4"
+    }) == "1.3.5"


### PR DESCRIPTION
See https://archriscv.felixc.at/.status/log.htm?url=logs/nvchecker/nvchecker-2.12-1.log.