### PR TITLE
github: implement option to include prereleases

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -390,6 +390,12 @@ use_latest_release
 
   Will return the release name instead of date.
 
+include_prereleases
+  When ``use_latest_release`` is ``true``, set this to ``true`` to take prereleases into
+  account.
+
+  This requires a token because it's using the v4 GraphQL API.
+
 use_latest_tag
   Set this to ``true`` to check for the latest tag on GitHub.
 
@@ -408,8 +414,8 @@ use_max_tag
 token
   A personal authorization token used to call the API.
 
-An authorization token may be needed in order to use ``use_latest_tag`` or to
-request more frequently than anonymously.
+An authorization token may be needed in order to use ``use_latest_tag``,
+``include_prereleases`` or to request more frequently than anonymously.
 
 To set an authorization token, you can set:
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -24,9 +24,17 @@ async def test_github_default_not_master(get_version):
 async def test_github_latest_release(get_version):
     assert await get_version("example", {
         "source": "github",
-        "github": "harry-sanabria/ReleaseTestRepo",
+        "github": "dpeukert/ReleaseTestRepo",
         "use_latest_release": True,
-    }) == "release3"
+    }) == "v0.0.0"
+
+async def test_github_latest_release_include_prereleases(get_version):
+    assert await get_version("example", {
+        "source": "github",
+        "github": "dpeukert/ReleaseTestRepo",
+        "use_latest_release": True,
+        "include_prereleases": True,
+    }) == "v0.0.1-pre"
 
 async def test_github_max_tag(get_version):
     assert await get_version("example", {


### PR DESCRIPTION
This PR adds the ability to return prereleases for the use_latest_release github option.