### PR TITLE
tests: bump example and xml2 version

### DIFF
--- a/tests/test_cran.py
+++ b/tests/test_cran.py
@@ -7,4 +7,4 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]
 async def test_cran(get_version):
     assert await get_version("xml2", {
         "source": "cran",
-    }) == "1.3.5"
+    }) == "1.3.6"

--- a/tests/test_cratesio.py
+++ b/tests/test_cratesio.py
@@ -7,4 +7,4 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]
 async def test_cratesio(get_version):
     assert await get_version("example", {
         "source": "cratesio",
-    }) == "0.1.0"
+    }) == "1.1.0"


### PR DESCRIPTION
crateios and cran released new version:

- [example](https://crates.io/crates/example)
- [xml2](https://cran.r-project.org/web/packages/xml2/index.html)