### PR TITLE
Fix container test for multi-arch images

### DIFF
--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -13,6 +13,14 @@ async def test_container(get_version):
   }) == "linux"
 
 async def test_container_with_tag(get_version):
+  update_time = await get_version("bitnami/mongodb:5.0", {
+    "source": "container",
+    "container": "bitnami/mongodb:5.0",
+  })
+  # the update time is changing occasionally, so we can not compare the exact time, otherwise the test will be failed in the future
+  assert datetime.date.fromisoformat(update_time.split('T')[0]) > datetime.date(2023, 12, 1)
+
+async def test_container_with_tag_and_multi_arch(get_version):
   update_time = await get_version("hello-world:linux", {
     "source": "container",
     "container": "library/hello-world:linux",


### PR DESCRIPTION
Fix #245

For multi-arch images, registry will return Manifest List instead of Image Manifest: https://distribution.github.io/distribution/spec/manifest-v2-2/#manifest-list.

In this case, we should choose one manifest and then send another request to get its detail.

Unfortunately, it's quite hard to find the manifest matching with current CPU architecture and system (docker and Python use different enum values for architecture, for example docker uses amd64 while Python uses x86_64).

Simply choosing the first manifest should probably work for most cases.