### PR TITLE
feat: add netrc support

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -375,6 +375,9 @@ branch
 path
   Only commits containing this file path will be returned.
 
+host
+  Hostname for self-hosted GitHub instance.
+
 use_latest_release
   Set this to ``true`` to check for the latest release on GitHub.
 
@@ -415,8 +418,9 @@ An authorization token may be needed in order to use ``use_latest_tag``,
 
 To set an authorization token, you can set:
 
-- a key named ``github`` in the keyfile
 - the token option
+- an entry in the keyfile for the host (e.g. ``github.com``)
+- an entry in your ``netrc`` file for the host
 
 This source supports :ref:`list options` when ``use_max_tag`` is set.
 
@@ -447,8 +451,9 @@ token
 
 To set an authorization token, you can set:
 
-- a key named ``gitea_{host}`` in the keyfile, where ``host`` is all-lowercased host name
 - the token option
+- an entry in the keyfile for the host (e.g. ``gitea.com``)
+- an entry in your ``netrc`` file for the host
 
 This source supports :ref:`list options` when ``use_max_tag`` is set.
 
@@ -520,8 +525,9 @@ token
 
 To set an authorization token, you can set:
 
-- a key named ``gitlab_{host}`` in the keyfile, where ``host`` is all-lowercased host name
 - the token option
+- an entry in the keyfile for the host (e.g. ``gitlab.com``)
+- an entry in your ``netrc`` file for the host
 
 This source supports :ref:`list options` when ``use_max_tag`` is set.
 

--- a/nvchecker_source/gitea.py
+++ b/nvchecker_source/gitea.py
@@ -33,8 +33,7 @@ async def get_version(
   token = conf.get('token')
   # Load token from keyman
   if token is None:
-    key_name = 'gitea_' + host.lower()
-    token = keymanager.get_key(key_name)
+    token = keymanager.get_key(host.lower(), 'gitea_' + host.lower())
 
   # Set private token if token exists.
   headers = {}

--- a/nvchecker_source/gitlab.py
+++ b/nvchecker_source/gitlab.py
@@ -42,8 +42,7 @@ async def get_version_real(
   token = conf.get('token')
   # Load token from keyman
   if token is None:
-    key_name = 'gitlab_' + host.lower()
-    token = keymanager.get_key(key_name)
+    token = keymanager.get_key(host.lower(), 'gitlab_' + host.lower())
 
   # Set private token if token exists.
   headers = {}


### PR DESCRIPTION
~~due to the removal of the prefix key in the token configuration, this is a breaking change.~~

closes #251

---

I tested and confirmed that I could use my netrc file (withou using the keyfile) to access the relevant gitlab token and it detected correctly the version update.
