### PR TITLE
feat: augment rich results

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -375,6 +375,9 @@ branch
 path
   Only commits containing this file path will be returned.
 
+host
+  Hostname for self-hosted GitHub instance.
+
 use_latest_release
   Set this to ``true`` to check for the latest release on GitHub.
 
@@ -415,8 +418,9 @@ An authorization token may be needed in order to use ``use_latest_tag``,
 
 To set an authorization token, you can set:
 
-- a key named ``github`` in the keyfile
 - the token option
+- an entry in the keyfile for the host (e.g. ``github.com``)
+- an entry in your ``netrc`` file for the host
 
 This source supports :ref:`list options` when ``use_max_tag`` is set.
 
@@ -447,8 +451,9 @@ token
 
 To set an authorization token, you can set:
 
-- a key named ``gitea_{host}`` in the keyfile, where ``host`` is all-lowercased host name
 - the token option
+- an entry in the keyfile for the host (e.g. ``gitea.com``)
+- an entry in your ``netrc`` file for the host
 
 This source supports :ref:`list options` when ``use_max_tag`` is set.
 
@@ -520,8 +525,9 @@ token
 
 To set an authorization token, you can set:
 
-- a key named ``gitlab_{host}`` in the keyfile, where ``host`` is all-lowercased host name
 - the token option
+- an entry in the keyfile for the host (e.g. ``gitlab.com``)
+- an entry in your ``netrc`` file for the host
 
 This source supports :ref:`list options` when ``use_max_tag`` is set.
 

--- a/nvchecker/core.py
+++ b/nvchecker/core.py
@@ -331,6 +331,8 @@ def _process_result(r: RawResult) -> Union[Result, Exception]:
   name = r.name
 
   url = None
+  revision = None
+  gitref = None
   if isinstance(version, GetVersionError):
     kw = version.kwargs
     kw['name'] = name
@@ -344,10 +346,14 @@ def _process_result(r: RawResult) -> Union[Result, Exception]:
     version_str = apply_list_options(version, conf)
     if isinstance(version_str, RichResult):
       url = version_str.url
+      gitref = version_str.gitref
+      revision = version_str.revision
       version_str = version_str.version
   elif isinstance(version, RichResult):
     version_str = version.version
     url = version.url
+    gitref = version.gitref
+    revision = version.revision
   else:
     version_str = version
 
@@ -356,7 +362,7 @@ def _process_result(r: RawResult) -> Union[Result, Exception]:
 
     try:
       version_str = substitute_version(version_str, conf)
-      return Result(name, version_str, conf, url)
+      return Result(name, version_str, conf, url, gitref, revision)
     except (ValueError, re.error) as e:
       logger.exception('error occurred in version substitutions', name=name)
       return e

--- a/nvchecker/util.py
+++ b/nvchecker/util.py
@@ -45,6 +45,8 @@ if sys.version_info[:2] >= (3, 10):
   @dataclass(kw_only=True)
   class RichResult:
     version: str
+    gitref: Optional[str] = None
+    revision: Optional[str] = None
     url: Optional[str] = None
 
     def __str__(self):
@@ -53,6 +55,8 @@ else:
   @dataclass
   class RichResult:
     version: str
+    gitref: Optional[str] = None
+    revision: Optional[str] = None
     url: Optional[str] = None
 
     def __str__(self):
@@ -142,6 +146,8 @@ class Result(NamedTuple):
   version: str
   conf: Entry
   url: Optional[str]
+  gitref: Optional[str]
+  revision: Optional[str]
 
 class BaseWorker:
   '''The base class for defining `Worker` classes for source plugins.

--- a/nvchecker_source/gitea.py
+++ b/nvchecker_source/gitea.py
@@ -45,11 +45,13 @@ async def get_version(
     return [
       RichResult(
         version = tag['name'],
+        revision = tag['id'],
         url = f'https://{host}/{conf["gitea"]}/releases/tag/{tag["name"]}',
       ) for tag in data
     ]
   else:
     return RichResult(
       version = data[0]['commit']['committer']['date'].split('T', 1)[0].replace('-', ''),
+      revision = data[0]['id'],
       url = data[0]['html_url'],
     )

--- a/nvchecker_source/gitea.py
+++ b/nvchecker_source/gitea.py
@@ -33,8 +33,7 @@ async def get_version(
   token = conf.get('token')
   # Load token from keyman
   if token is None:
-    key_name = 'gitea_' + host.lower()
-    token = keymanager.get_key(key_name)
+    token = keymanager.get_key(host.lower(), 'gitea_' + host.lower())
 
   # Set private token if token exists.
   headers = {}

--- a/nvchecker_source/gitlab.py
+++ b/nvchecker_source/gitlab.py
@@ -54,12 +54,14 @@ async def get_version_real(
     return [
       RichResult(
         version = tag['name'],
+        revision = tag['commit']['id'],
         url = f'https://{host}/{conf["gitlab"]}/-/tags/{tag["name"]}',
       ) for tag in data
     ]
   else:
     return RichResult(
       version = data[0]['created_at'].split('T', 1)[0].replace('-', ''),
+      revision = data[0]['id'],
       url = data[0]['web_url'],
     )
 

--- a/nvchecker_source/gitlab.py
+++ b/nvchecker_source/gitlab.py
@@ -42,8 +42,7 @@ async def get_version_real(
   token = conf.get('token')
   # Load token from keyman
   if token is None:
-    key_name = 'gitlab_' + host.lower()
-    token = keymanager.get_key(key_name)
+    token = keymanager.get_key(host.lower(), 'gitlab_' + host.lower())
 
   # Set private token if token exists.
   headers = {}


### PR DESCRIPTION
- feat: add netrc support
- feat: add configurable host to github
- docs: document changes don't mention the old keys
- ↑ #252 

----
- feat: add richer results
- feat: implement more metadata for git{,hub,lab}

On top of #252, this implements expanded metadata on rich results motivated by #253.

The latter will be rebased in case this gets merged and that would allow for more
clarity on how to maybe expand the api with a suitable extension point so that
similar use cases like #253 can be implemented cleanly out of tree.
