### PR TITLE
feat/towards writer extension point

### DIFF
--- a/nvchecker/core.py
+++ b/nvchecker/core.py
@@ -394,7 +394,7 @@ async def process_result(
   result_q: Queue[RawResult],
   entry_waiter: EntryWaiter,
   verbose: bool = False,
-) -> Tuple[VersData, bool]:
+) -> Tuple[ResultData, bool]:
   ret = {}
   has_failures = False
   try:
@@ -411,7 +411,7 @@ async def process_result(
         continue
       check_version_update(oldvers, r1, verbose)
       entry_waiter.set_result(r1.name, r1.version)
-      ret[r1.name] = r1.version
+      ret[r1.name] = r1
   except asyncio.CancelledError:
     return ret, has_failures
 

--- a/nvchecker/util.py
+++ b/nvchecker/util.py
@@ -153,6 +153,8 @@ class Result(NamedTuple):
   gitref: Optional[str]
   revision: Optional[str]
 
+ResultData = Dict[str, Result]
+
 class BaseWorker:
   '''The base class for defining `Worker` classes for source plugins.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,8 +47,8 @@ async def run(
   result_coro = core.process_result(oldvers, result_q, entry_waiter)
   runner_coro = core.run_tasks(futures)
 
-  vers, _has_failures = await main.run(result_coro, runner_coro)
-  return vers
+  results, _has_failures = await main.run(result_coro, runner_coro)
+  return {k: r.version for k, r in results.items()}
 
 @pytest_asyncio.fixture(scope="session")
 async def get_version():


### PR DESCRIPTION
- feat: log up-to-date when single entry
- fix: #255

---

- feat: return full results from result processing

# Context

https://github.com/lilydjwg/nvchecker/pull/253 prototypes a "writer" implementation.

It takes a version result and not only updates references but then also mutates the code base on the basis of the newly obtained references.

A Nix writer is certainly no good in-tree use case.

Hence, this PR tries to conceptualize a potential extension point for downstream packages which could implement writer implementations similarly as, today, `nvfetcher_source` provides source implementations.
