### PR TITLE
fix: correct try/except statement

### DIFF
--- a/tests/test_jq.py
+++ b/tests/test_jq.py
@@ -6,7 +6,7 @@ import pytest
 jq_available = True
 try:
   import jq
-except jq:
+except ImportError:
   jq_available = False
 
 pytestmark = [


### PR DESCRIPTION
Otherwise, it fails because Python can't find the `jq` exception.
```
==================================== ERRORS ====================================
______________________ ERROR collecting tests/test_jq.py _______________________
tests/test_jq.py:8: in <module>
    import jq
E   ModuleNotFoundError: No module named 'jq'

During handling of the above exception, another exception occurred:
tests/test_jq.py:9: in <module>
    except jq:
E   NameError: name 'jq' is not defined
```