### PR TITLE
pypi: support list options

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -570,6 +570,8 @@ pypi
 use_pre_release
   Whether to accept pre release. Default is false.
 
+This source supports :ref:`list options`.
+
 .. note::
    An additional dependency "packaging" is required.
    You can use ``pip install 'nvchecker[pypi]'``.

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -20,3 +20,9 @@ async def test_pypi_pre_release(get_version):
         "source": "pypi",
         "use_pre_release": 1,
     }) == "1.0.1a1"
+
+async def test_pypi_list(get_version):
+    assert await get_version("urllib3", {
+        "source": "pypi",
+        "include_regex": "^1\\..*",
+    }) == "1.26.18"

--- a/tests/test_ubuntupkg.py
+++ b/tests/test_ubuntupkg.py
@@ -1,5 +1,5 @@
 # MIT licensed
-# Copyright (c) 2020 lilydjwg <lilydjwg@gmail.com>, et al.
+# Copyright (c) 2020,2024 lilydjwg <lilydjwg@gmail.com>, et al.
 # Copyright (c) 2017 Felix Yan <felixonmars@archlinux.org>, et al.
 
 import pytest
@@ -7,9 +7,10 @@ pytestmark = [pytest.mark.asyncio(scope="session"), pytest.mark.needs_net]
 
 @pytest.mark.flaky
 async def test_ubuntupkg(get_version):
-    assert await get_version("sigrok-firmware-fx2lafw", {
+    v = await get_version("sigrok-firmware-fx2lafw", {
         "source": "ubuntupkg",
-    }) == "0.1.7-1"
+    })
+    assert v.startswith("0.1.7-")
 
 @pytest.mark.flaky
 async def test_ubuntupkg_strip_release(get_version):


### PR DESCRIPTION
From time to time, I need to ignore broken versions on PyPI. `ignored` or `exclude_regex` is part of list options, hence the patch.

In the new test, I use `include_regex`, which should make the test more resilient to future changes.

While I'm at it, I also cherry-picked a CI fix from the test-ci branch.