### PR TITLE
Add launchpad source

### DIFF
--- a/nvchecker_source/launchpad.py
+++ b/nvchecker_source/launchpad.py
@@ -1,0 +1,20 @@
+# MIT Licensed
+# Copyright (c) 2024 Bert Peters <bertptrs@archlinux.org>, et al.
+from __future__ import annotations
+from nvchecker.api import AsyncCache, Entry, RichResult
+
+PROJECT_INFO_URL = "https://api.launchpad.net/1.0/{launchpad}"
+
+async def get_version(name: str, conf: Entry, *, cache: AsyncCache, **kwargs):
+  launchpad = conf["launchpad"]
+
+  project_data = await cache.get_json(PROJECT_INFO_URL.format(launchpad=launchpad))
+  data = await cache.get_json(project_data['releases_collection_link'])
+
+  return [
+    RichResult(version=entry["version"], url=entry["web_link"])
+    for entry in data["entries"]
+  ]
+
+
+

--- a/tests/test_launchpad.py
+++ b/tests/test_launchpad.py
@@ -1,0 +1,15 @@
+# MIT Licensed
+# Copyright (c) 2024 Bert Peters <bertptrs@archlinux.org>, et al.
+import pytest
+pytestmark = [pytest.mark.asyncio(scope="session"), pytest.mark.needs_net]
+
+async def test_launchpad(get_version):
+  version = await get_version(
+    "sakura",
+    {
+      "source": "launchpad",
+      "launchpad": "sakura",
+    }
+  )
+
+  assert version == '3.8.7'


### PR DESCRIPTION
Add Launchpad a source for nvchecker.

This plugin only takes a single parameter:

- `launchpad`, the name of the package on Launchpad

The plugin returns however many releases are returned by the API, which appear to be returned in reverse chronological order, though this is not documented. See: https://launchpad.net/+apidoc/1.0.html#project