### PR TITLE
anitya: support to use anitya ID

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -757,6 +757,11 @@ This enables you to track updates from `Anitya <https://release-monitoring.org/>
 anitya
   ``distro/package``, where ``distro`` can be a lot of things like "fedora", "arch linux", "gentoo", etc. ``package`` is the package name of the chosen distribution.
 
+anitya_id
+  The identifier of the project/package in anitya.
+
+Note that either anitya or anitya_id needs to be specified, anitya_id is preferred when both specified.
+
 Check Android SDK
 ~~~~~~~~~~~~~~~~~
 ::

--- a/nvchecker_source/anitya.py
+++ b/nvchecker_source/anitya.py
@@ -6,7 +6,9 @@ from nvchecker.api import RichResult
 URL = 'https://release-monitoring.org/api/project/{pkg}'
 
 async def get_version(name, conf, *, cache, **kwargs):
-  pkg = conf.get('anitya')
+  pkg = conf.get('anitya_id')
+  if pkg is None:
+    pkg = conf.get('anitya')
   url = URL.format(pkg = pkg)
   data = await cache.get_json(url)
   return RichResult(

--- a/tests/test_anitya.py
+++ b/tests/test_anitya.py
@@ -13,3 +13,10 @@ async def test_anitya(get_version):
     "anitya": "fedora/shutter",
   })
   assert re.match(r"[0-9.]+", version)
+
+async def test_anitya_by_id(get_version):
+  version = await get_version("shutter", {
+    "source": "anitya",
+    "anitya_id": "4813",
+  })
+  assert re.match(r"[0-9.]+", version)


### PR DESCRIPTION
When using anitya, we need to go to https://release-monitoring.org/ and find out which distribution are linking to the project. So why don't we just use the ID.

https://release-monitoring.org/static/docs/api.html#get--api-project-(int-project_id)