### PR TITLE
update tests

### DIFF
--- a/tests/test_android_sdk.py
+++ b/tests/test_android_sdk.py
@@ -18,7 +18,7 @@ async def test_android_package(get_version):
         "android_sdk": "cmake;",
         "repo": "package",
     })
-    assert version.startswith("3.30.")
+    assert version.startswith("3.")
 
 
 async def test_android_package_channel(get_version):


### PR DESCRIPTION
Further relax the test. The android-sdk-cmake package is now at 3.31.0.

By the way, how do you think about a new release? Looking forward to official Python 3.13 support.