### PR TITLE
feat: include revision in logging output

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -71,8 +71,8 @@ The JSON log is one JSON string per line. The following documented events and
 fields are stable, undocumented ones may change without notice.
 
 event=updated
-  An update is detected. Fields ``name``, ``old_version`` and ``version`` are
-  available. ``old_version`` maybe ``null``.
+  An update is detected. Fields ``name``, ``revision``, ``old_version`` and ``version`` are
+  available. ``old_version`` and ``revision`` maybe ``null``.
 
 event=up-to-date
   There is no update. Fields ``name`` and ``version`` are available.

--- a/nvchecker/core.py
+++ b/nvchecker/core.py
@@ -417,6 +417,7 @@ def check_version_update(
       'updated',
       name = name,
       version = r.version,
+      revision = r.revision,
       old_version = oldver,
       url = r.url,
     )

--- a/nvchecker/slogconf.py
+++ b/nvchecker/slogconf.py
@@ -26,6 +26,9 @@ def _console_msg(event):
   else:
     msg = evt
 
+  if 'revision' in event and not event['revision']:
+      del event['revision']
+
   if 'name' in event:
     msg = f"{event['name']}: {msg}"
     del event['name']


### PR DESCRIPTION
I'd like to track package updates using the tags then refer to the updates by their commit hash (as recommended by https://wiki.archlinux.org/title/Arch_package_guidelines#Package_sources, bullet #3).

Confirmed this works with `use_latest_tags=true` (revision is null) as well as `use_max_tag=true`.