### PR TITLE
Exclude yanked PyPI releases

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -589,7 +589,7 @@ Check PyPI
 
   source = "pypi"
 
-Check `PyPI <https://pypi.python.org/>`_ for updates.
+Check `PyPI <https://pypi.python.org/>`_ for updates. Yanked releases are ignored.
 
 pypi
   The name used on PyPI, e.g. ``PySide``.
@@ -683,7 +683,7 @@ Check crates.io
 
   source = "cratesio"
 
-Check `crates.io <https://crates.io/>`_ for updates.
+Check `crates.io <https://crates.io/>`_ for updates. Yanked releases are ignored.
 
 cratesio
   The crate name on crates.io, e.g. ``tokio``.

--- a/nvchecker_source/pypi.py
+++ b/nvchecker_source/pypi.py
@@ -20,7 +20,7 @@ async def get_version(name, conf, *, cache, **kwargs):
 
   for version in data['releases'].keys():
     # Skip versions that are marked as yanked.
-    if len(data['releases'][version]) != 0 and data['releases'][version][0]['yanked']:
+    if (vers := data['releases'][version]) and vers[0]['yanked']:
       continue
 
     try:

--- a/nvchecker_source/pypi.py
+++ b/nvchecker_source/pypi.py
@@ -19,6 +19,10 @@ async def get_version(name, conf, *, cache, **kwargs):
   data = await cache.get_json(url)
 
   for version in data['releases'].keys():
+    # Skip versions that are marked as yanked.
+    if len(data['releases'][version]) != 0 and data['releases'][version][0]['yanked']:
+      continue
+
     try:
       parsed_version = Version(version)
     except InvalidVersion:

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,10 +39,10 @@ classifiers =
 
 [options]
 zip_safe = True
+python_requires = >=3.8
 
 packages = find_namespace:
 install_requires =
-  setuptools; python_version<"3.8"
   tomli; python_version<"3.11"
   structlog
   platformdirs

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -32,3 +32,8 @@ async def test_pypi_invalid_version(get_version):
         "source": "pypi",
     })
 
+async def test_pypi_yanked_version(get_version):
+    assert await get_version("urllib3", {
+        "source": "pypi",
+        "include_regex": "^(1\\..*)|(2\\.0\\.[0,1])",
+    }) == "1.26.20"


### PR DESCRIPTION
PyPI has a feature that allows a project maintainer to yank a release. crates.io has the same feature and the source already implements that:
https://github.com/lilydjwg/nvchecker/blob/4364759b295cf2b91402fe3270fc03338e276cb0/nvchecker_source/cratesio.py#L24-L25

This PR adds the same feature to the PyPI source.