### PR TITLE
Implement use_max_release for github

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -399,8 +399,8 @@ Check GitHub
   source = "github"
 
 Check `GitHub <https://github.com/>`_ for updates. The version returned is in
-date format ``%Y%m%d.%H%M%S``, e.g. ``20130701.012212``, unless ``use_latest_release``
-or ``use_max_tag`` is used. See below.
+date format ``%Y%m%d.%H%M%S``, e.g. ``20130701.012212``, unless ``use_latest_release``,
+``use_max_tag`` or ``use_max_release`` is used. See below.
 
 github
   The github repository, with author, e.g. ``lilydjwg/nvchecker``.
@@ -426,13 +426,19 @@ use_latest_release
   Will return the release's tag name instead of date. (For historical reasons
   it doesn't return the release name. See below to change.)
 
+use_max_release
+  Set this to ``true`` to check for the max release on GitHub.
+  This option returns the largest one sorted by the
+  ``sort_version_key`` option. Will return the tag name instead of date.
+
 use_release_name
-  When ``use_latest_release`` is ``true``, setting this to ``true`` will cause
-  nvchecker to return the release name instead of the tag name.
+  When ``use_latest_release`` or ``use_max_release`` is ``true``,
+  setting this to ``true`` will cause nvchecker to return the release name
+  instead of the tag name.
 
 include_prereleases
-  When ``use_latest_release`` is ``true``, set this to ``true`` to take prereleases into
-  account.
+  When ``use_latest_release`` or ``use_max_release`` is ``true``,
+  set this to ``true`` to take prereleases into account.
 
   This returns the release names (not the tag names).
 
@@ -449,7 +455,7 @@ query
 
 use_max_tag
   Set this to ``true`` to check for the max tag on GitHub. Unlike
-  ``use_latest_release``, this option includes both annotated tags and
+  ``use_max_release``, this option includes both annotated tags and
   lightweight ones, and return the largest one sorted by the
   ``sort_version_key`` option. Will return the tag name instead of date.
 
@@ -465,7 +471,8 @@ To set an authorization token, you can set:
 - an entry in the keyfile for the host (e.g. ``github.com``)
 - an entry in your ``netrc`` file for the host
 
-This source supports :ref:`list options` when ``use_max_tag`` is set.
+This source supports :ref:`list options` when ``use_max_tag`` or
+``use_max_release`` is set.
 
 Check Gitea
 ~~~~~~~~~~~

--- a/scripts/nvchecker-ini2toml
+++ b/scripts/nvchecker-ini2toml
@@ -18,7 +18,7 @@ _handler_precedence = (
 BOOL_KEYS = [
   'strip_release', 'use_last_modified',
   'use_latest_release', 'use_latest_tag',
-  'use_max_tag', 'use_pre_release',
+  'use_max_release', 'use_max_tag', 'use_pre_release',
 ]
 
 INT_KEYS = [

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -59,6 +59,20 @@ async def test_github_max_tag(get_version):
         "use_max_tag": True,
     }) == "second_release"
 
+async def test_github_max_release(get_version):
+    assert await get_version("example", {
+        "source": "github",
+        "github": "harry-sanabria/ReleaseTestRepo",
+        "use_max_release": True,
+    }) == "second_release"
+
+    assert await get_version("example", {
+        "source": "github",
+        "github": "harry-sanabria/ReleaseTestRepo",
+        "use_max_release": True,
+        "use_release_name": True,
+    }) == "second_release"
+
 async def test_github_max_tag_with_ignored(get_version):
     assert await get_version("example", {
         "source": "github",
@@ -66,6 +80,21 @@ async def test_github_max_tag_with_ignored(get_version):
         "use_max_tag": True,
         "ignored": "second_release release3",
     }) == "first_release"
+
+async def test_github_max_release_with_ignored(get_version):
+    assert await get_version("example", {
+        "source": "github",
+        "github": "harry-sanabria/ReleaseTestRepo",
+        "use_max_release": True,
+        "ignored": "second_release release3",
+    }) == "first_release"
+    assert await get_version("example", {
+        "source": "github",
+        "github": "harry-sanabria/ReleaseTestRepo",
+        "use_max_release": True,
+        "ignored": "second_release",
+        "use_release_name": True,
+    }) == "release #3"
 
 async def test_github_with_path(get_version):
     assert await get_version("example", {
@@ -90,6 +119,16 @@ async def test_github_max_tag_with_include(get_version):
         "include_regex": r"chrome-\d.*",
     })
     assert re.match(r'chrome-[\d.]+', version)
+
+async def test_github_max_release_with_include(get_version):
+    version = await get_version("example", {
+        "source": "github",
+        "github": "EFForg/https-everywhere",
+        "use_max_release": True,
+        "use_release_name": True,
+        "include_regex": r"Release \d.*",
+    })
+    assert re.match(r'Release [\d.]+', version)
 
 async def test_github_latest_tag(get_version):
     assert await get_version("example", {


### PR DESCRIPTION
This follows the logic for use_max_tag but only includes the tags that are part of a github release. The returned version follows include_prerelease and use_release_name just like use_latest_release.

This allows waiting for release artifacts to be created after the tag is created on the repo. I needed this for `electron*-bin` since there could be a delay (at least a day sometimes it seems) between tag creation and artifacts upload.