### PR TITLE
feat: add a source for Maven

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -651,6 +651,21 @@ Check `Hackage <https://hackage.haskell.org/>`_ for updates.
 hackage
   The name used on Hackage, e.g. ``pandoc``.
 
+Check Maven
+~~~~~~~~~~~
+::
+
+  source = "maven"
+
+Check a `Maven repository <https://maven.apache.org/>`_ for updates.
+
+repo
+  URL of the repository to check (defaults to ``https://repo1.maven.org/maven2``).
+group
+  Group identifier for the coordinates.
+artifact
+  Artifact identifier for the coordinates.
+
 Check CPAN
 ~~~~~~~~~~
 ::

--- a/nvchecker_source/maven.py
+++ b/nvchecker_source/maven.py
@@ -1,0 +1,56 @@
+# MIT licensed
+# Copyright (c) 2025 Dani Rodríguez <dani@danirod.es>, et al.
+
+from nvchecker.api import (
+    Entry,
+    KeyManager,
+    AsyncCache,
+    VersionResult,
+    GetVersionError,
+    HTTPError,
+    session,
+)
+import pathlib
+from xml.etree import ElementTree
+
+
+MAVEN_CENTRAL = "https://repo1.maven.org/maven2"
+
+
+async def get_version(
+    name: str,
+    conf: Entry,
+    *,
+    cache: AsyncCache,
+    keymanager: KeyManager,
+    **kwargs,
+) -> VersionResult:
+    # get project coordinates
+    group_id, artifact_id = conf.get("group"), conf.get("artifact")
+    if not group_id:
+        raise GetVersionError("Group identifier is not given")
+    if not artifact_id:
+        raise GetVersionError("Artifact identifier is not given")
+    group_id = group_id.replace(".", "/")
+
+    # build the URL according to the transformation rules
+    # -> https://maven.apache.org/repositories/layout.html
+    repo = conf.get("repo", MAVEN_CENTRAL)
+    repo_root = pathlib.PurePosixPath(repo)
+    artifact_path = repo_root / group_id / artifact_id / "maven-metadata.xml"
+
+    try:
+        version = await cache.get(str(artifact_path), extract_metadata)
+        if version is None:
+            raise GetVersionError(f"Failed to get version for {group_id}:{artifact_id}")
+        return version
+    except HTTPError:
+        raise GetVersionError(f"Failed to fetch metadata for {group_id}:{artifact_id}")
+
+
+async def extract_metadata(url):
+    metadata = await session.get(url)
+    root = ElementTree.fromstring(metadata.body)
+    release = root.find("./versioning/release")
+    if release is not None:
+        return release.text

--- a/tests/test_maven.py
+++ b/tests/test_maven.py
@@ -1,0 +1,68 @@
+# MIT licensed
+# Copyright (c) 2025 Dani Rodríguez <dani@danirod.es>, et al.
+
+import pytest
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]
+
+
+async def test_maven(get_version):
+    # this package has been moved to a new name, so no new
+    # versions should ever be published under this name
+    assert (
+        await get_version(
+            "javax-persistence-api",
+            {
+                "source": "maven",
+                "group": "javax.persistence",
+                "artifact": "javax.persistence-api",
+            },
+        )
+        == "2.2"
+    )
+
+
+async def test_maven_custom_repo(get_version):
+    # this package has also been phased out in favour of another
+    # so the version number should not bump unexpectedly
+    assert (
+        await get_version(
+            "play-services",
+            {
+                "source": "maven",
+                "repo": "https://maven.google.com",
+                "group": "com.google.android.gms",
+                "artifact": "play-services",
+            },
+        )
+        == "12.0.1"
+    )
+
+
+async def test_maven_non_existing_group(get_version):
+    with pytest.raises(
+        RuntimeError, match="Failed to fetch metadata for javax:not-exists"
+    ):
+        assert await get_version(
+            "persistence",
+            {
+                "source": "maven",
+                "group": "javax",
+                "artifact": "not-exists",
+            },
+        )
+
+
+async def test_maven_cannot_find_release(get_version):
+    # not exactly the way to pass parameters, but when concatted, it returns
+    # an XML document without versioning info, so it allows to test decode
+    # errors -> https://repo1.maven.org/maven2/org/apache/maven-metadata.xml
+    with pytest.raises(RuntimeError, match="Failed to get version for org:apache"):
+        assert await get_version(
+            "apache",
+            {
+                "source": "maven",
+                "group": "org",
+                "artifact": "apache",
+            },
+        )


### PR DESCRIPTION
This PR adds a new source called "maven" that allows to fetch for new version releases from a Maven repository. As described in the updated docs, the coordinates have to be given. The repository is optional and it assumes it's Maven Central unless told otherwise.

I think this will also complete #174.