### PR TITLE
add use_latest_release for gitea

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -417,7 +417,7 @@ host
 use_latest_release
   Set this to ``true`` to check for the latest release on GitHub.
 
-  GitHub releases are not the same with git tags. You'll see big version names
+  GitHub releases are not the same as git tags. You'll see big version names
   and descriptions in the release page for such releases, e.g.
   `zfsonlinux/zfs's <https://github.com/zfsonlinux/zfs/releases>`_, and those
   small ones like `nvchecker's <https://github.com/lilydjwg/nvchecker/releases>`_
@@ -492,6 +492,13 @@ branch
 use_max_tag
   Set this to ``true`` to check for the max tag on Gitea. Will return the biggest one
   sorted by old ``pkg_resources.parse_version``. Will return the tag name instead of date.
+
+use_latest_release
+  Set this to ``true`` to check for the latest release on gitea.
+
+  Gitea releases are not the same as git tags. You'll see big version names
+  and descriptions in the release page for such releases, e.g.
+  `ciberandy/qiv's <https://codeberg.org/ciberandy/qiv/releases>`_
 
 host
   Hostname for self-hosted Gitea instance.

--- a/nvchecker_source/gitea.py
+++ b/nvchecker_source/gitea.py
@@ -7,10 +7,11 @@ import urllib.parse
 
 GITEA_URL = 'https://%s/api/v1/repos/%s/commits'
 GITEA_MAX_TAG = 'https://%s/api/v1/repos/%s/tags'
+GITEA_LATEST_RELEASE = 'https://%s/api/v1/repos/%s/releases'
 
 from nvchecker.api import (
   VersionResult, RichResult, Entry,
-  AsyncCache, KeyManager,
+  AsyncCache, KeyManager, GetVersionError
 )
 
 async def get_version(
@@ -21,9 +22,14 @@ async def get_version(
   br = conf.get('branch')
   host = conf.get('host', 'gitea.com')
   use_max_tag = conf.get('use_max_tag', False)
+  use_latest_release = conf.get('use_latest_release', False)
+  if use_max_tag and use_latest_release:
+      raise GetVersionError('You cannot specify both use_max_tag and use_latest_release')
 
   if use_max_tag:
     url = GITEA_MAX_TAG % (host, repo)
+  elif use_latest_release:
+    url = GITEA_LATEST_RELEASE % (host, repo)
   else:
     url = GITEA_URL % (host, repo)
     if br:
@@ -49,6 +55,12 @@ async def get_version(
         url = f'https://{host}/{conf["gitea"]}/releases/tag/{tag["name"]}',
       ) for tag in data
     ]
+  elif use_latest_release:
+    return RichResult(
+      version = data[0]['name'],
+      gitref = f"refs/tags/{data[0]['tag_name']}",
+      url = data[0]['html_url'],
+    )
   else:
     return RichResult(
       version = data[0]['commit']['committer']['date'],


### PR DESCRIPTION
Hi, I maintain qiv package for AUR. It is hosted on codeberg which uses gitea. It uses the release feature. So I'd like to monitor new  releases on gitea. This is patch proposal that adds a parameter similar to the one used in github.