### PR TITLE
test: fix failures

### DIFF
--- a/tests/test_android_sdk.py
+++ b/tests/test_android_sdk.py
@@ -19,7 +19,7 @@ async def test_android_package(get_version):
         "android_sdk": "cmake;",
         "repo": "package",
     })
-    assert version.startswith("3.")
+    assert version.startswith("4.")
 
 
 async def test_android_package_channel(get_version):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 isolated_build = True
 # you may find `tox --skip-missing-interpreters=true` helpful.
-envlist = py3{8,9,10,11,12}
+envlist = py3{8,9,10,11,12,13}
 
 [testenv]
 usedevelop = false
@@ -9,7 +9,7 @@ deps =
   pytest
   pytest-asyncio
   pytest-httpbin
-  flaky
+  pytest-rerunfailures
 extras =
   htmlparser
 passenv = KEYFILE


### PR DESCRIPTION
- add py313 to tox
- replace flaky with pytest-rerunfailures to fix  
     _FlakyPlugin._make_test_flaky() got an unexpected keyword argument 'reruns'
- bump android-sdk-cmake to 4