### PR TITLE
gitlab: add gitref to tag results

### DIFF
--- a/nvchecker_source/gitlab.py
+++ b/nvchecker_source/gitlab.py
@@ -52,6 +52,7 @@ async def get_version_real(
     return [
       RichResult(
         version = tag['name'],
+        gitref = f"refs/tags/{tag['name']}",
         revision = tag['commit']['id'],
         url = f'https://{host}/{conf["gitlab"]}/-/tags/{tag["name"]}',
       ) for tag in data


### PR DESCRIPTION
GitHub and git sources already include `gitref` in tag-based `RichResult` values. GitLab `use_max_tag` results currently include `version`, `revision`, and `url`, but not the corresponding ref name.

Add `gitref = f"refs/tags/{tag['name']}"` to GitLab tag results so callers can trace the selected version back to the exact upstream Git ref after normalization.

This does not change version selection, sorting, filtering, revision handling, or URLs.

Existing source tests assert selected versions only; this change only adds metadata to `RichResult` and does not affect version selection.