### PR TITLE
git_pygit2: add optional git source backend using pygit2

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -953,6 +953,32 @@ branch
 
 When this source returns tags (``use_commit`` is not true) it supports :ref:`list options`.
 
+Check Git repository without git CLI
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+::
+
+  source = "git_pygit2"
+
+This is equivalent to the ``git`` source, but uses pygit2/libgit2 instead of
+invoking the ``git`` executable. It is useful in environments where Python
+packages can be installed but external binaries cannot be executed.
+
+git
+  URL of the Git repository.
+
+use_commit
+  Return a commit hash instead of tags.
+
+branch
+  When ``use_commit`` is true, return the commit on the specified branch instead
+  of the default one.
+
+When this source returns tags (``use_commit`` is not true) it supports
+:ref:`list options`.
+
+.. note::
+   An additional dependency ``pygit2`` is required.
+
 Check Mercurial repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -959,7 +959,7 @@ Check Git repository without git CLI
 
   source = "git_pygit2"
 
-This is equivalent to the ``git`` source, but uses pygit2/libgit2 instead of
+This is similar to the ``git`` source, but uses pygit2/libgit2 instead of
 invoking the ``git`` executable. It is useful in environments where Python
 packages can be installed but external binaries cannot be executed.
 

--- a/nvchecker_source/git_pygit2.py
+++ b/nvchecker_source/git_pygit2.py
@@ -10,67 +10,67 @@ from nvchecker.api import RichResult, GetVersionError
 
 
 async def _list_remote_refs_async(key):
-  return await asyncio.to_thread(_list_remote_refs, key)
+    return await asyncio.to_thread(_list_remote_refs, key)
 
 
 def _list_remote_refs(key):
-  git, ref = key
+    git, ref = key
 
-  with tempfile.TemporaryDirectory() as tmpdir:
-    repo = pygit2.init_repository(tmpdir, bare=True)
-    remote = repo.remotes.create_anonymous(git)
-    refs = remote.list_heads()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo = pygit2.init_repository(tmpdir, bare=True)
+        remote = repo.remotes.create_anonymous(git)
+        refs = remote.list_heads()
 
-  if ref is None:
-    return refs
-
-  return [r for r in refs if r.name == ref]
-
-
-async def get_version(
-  name, conf, *, cache, keymanager=None
-):
-  git = conf['git']
-
-  use_commit = conf.get('use_commit', False)
-  if use_commit:
-    ref = conf.get('branch')
     if ref is None:
-      ref = 'HEAD'
-      gitref = None
-    else:
-      ref = 'refs/heads/' + ref
-      gitref = ref
+        return refs
 
-    refs = await cache.get((git, ref), _list_remote_refs_async)
-    if not refs:
-      raise GetVersionError('No ref found in upstream repository.', ref=ref)
+    return [r for r in refs if r.name == ref]
 
-    version = str(refs[0].oid)
-    return RichResult(
-      version = version,
-      revision = version,
-      gitref = gitref,
-    )
 
-  refs = await cache.get((git, None), _list_remote_refs_async)
+async def get_version(name, conf, *, cache, keymanager=None):
+    git = conf["git"]
 
-  versions = []
-  for ref in refs:
-    if not ref.name.startswith('refs/tags/'):
-      continue
-    if ref.name.endswith('^{}'):
-      continue
+    use_commit = conf.get("use_commit", False)
+    if use_commit:
+        ref = conf.get("branch")
+        if ref is None:
+            ref = "HEAD"
+            gitref = None
+        else:
+            ref = "refs/heads/" + ref
+            gitref = ref
 
-    version = ref.name.removeprefix('refs/tags/')
-    revision = str(ref.oid)
-    versions.append(RichResult(
-      version = version,
-      revision = revision,
-      gitref = ref.name,
-    ))
+        refs = await cache.get((git, ref), _list_remote_refs_async)
+        if not refs:
+            raise GetVersionError("No ref found in upstream repository.", ref=ref)
 
-  if not versions:
-    raise GetVersionError('No tag found in upstream repository.')
+        version = str(refs[0].oid)
+        return RichResult(
+            version=version,
+            revision=version,
+            gitref=gitref,
+        )
 
-  return versions
+    refs = await cache.get((git, None), _list_remote_refs_async)
+
+    versions = []
+    for ref in refs:
+        if not ref.name.startswith("refs/tags/"):
+            continue
+        if ref.name.endswith("^{}"):
+            continue
+
+        version = ref.name.removeprefix("refs/tags/")
+        revision = str(ref.oid)
+        versions.append(
+            RichResult(
+                version=version,
+                revision=revision,
+                gitref=ref.name,
+            )
+        )
+
+    if not versions:
+        raise GetVersionError("No tag found in upstream repository.")
+
+    return versions

--- a/nvchecker_source/git_pygit2.py
+++ b/nvchecker_source/git_pygit2.py
@@ -4,7 +4,7 @@
 import asyncio
 import tempfile
 
-import pygit2
+import pygit2  # type: ignore[import-not-found]
 
 from nvchecker.api import RichResult, GetVersionError
 

--- a/nvchecker_source/git_pygit2.py
+++ b/nvchecker_source/git_pygit2.py
@@ -1,0 +1,76 @@
+# MIT licensed
+# Copyright (c) 2026 Lorenzo Pirritano <lorepirri@gmail.com>
+
+import asyncio
+import tempfile
+
+import pygit2
+
+from nvchecker.api import RichResult, GetVersionError
+
+
+async def _list_remote_refs_async(key):
+  return await asyncio.to_thread(_list_remote_refs, key)
+
+
+def _list_remote_refs(key):
+  git, ref = key
+
+  with tempfile.TemporaryDirectory() as tmpdir:
+    repo = pygit2.init_repository(tmpdir, bare=True)
+    remote = repo.remotes.create_anonymous(git)
+    refs = remote.list_heads()
+
+  if ref is None:
+    return refs
+
+  return [r for r in refs if r.name == ref]
+
+
+async def get_version(
+  name, conf, *, cache, keymanager=None
+):
+  git = conf['git']
+
+  use_commit = conf.get('use_commit', False)
+  if use_commit:
+    ref = conf.get('branch')
+    if ref is None:
+      ref = 'HEAD'
+      gitref = None
+    else:
+      ref = 'refs/heads/' + ref
+      gitref = ref
+
+    refs = await cache.get((git, ref), _list_remote_refs_async)
+    if not refs:
+      raise GetVersionError('No ref found in upstream repository.', ref=ref)
+
+    version = str(refs[0].oid)
+    return RichResult(
+      version = version,
+      revision = version,
+      gitref = gitref,
+    )
+
+  refs = await cache.get((git, None), _list_remote_refs_async)
+
+  versions = []
+  for ref in refs:
+    if not ref.name.startswith('refs/tags/'):
+      continue
+    if ref.name.endswith('^{}'):
+      continue
+
+    version = ref.name.removeprefix('refs/tags/')
+    revision = str(ref.oid)
+    versions.append(RichResult(
+      version = version,
+      revision = revision,
+      gitref = ref.name,
+    ))
+
+  if not versions:
+    raise GetVersionError('No tag found in upstream repository.')
+
+  return versions

--- a/sample_config.toml
+++ b/sample_config.toml
@@ -17,6 +17,10 @@ github = "lilydjwg/winterpy"
 source = "github"
 github = "lilydjwg/nvchecker"
 
+[gitlab-test-pygit2]
+source = "git_pygit2"
+git = "https://gitlab.com/gitlab-org/gitlab-test.git"
+
 [ssed]
 source = "regex"
 regex = "The current version is ([\\d.]+)\\."

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,8 @@ rpmrepo =
   zstandard; python_version<"3.14"
 jq =
   jq
+git_pygit2 =
+  pygit2
 
 [options.entry_points]
 console_scripts =

--- a/tests/test_git_pygit2.py
+++ b/tests/test_git_pygit2.py
@@ -6,7 +6,7 @@ import pytest
 # Skip all tests in this file if pygit2 is not installed
 pygit2_available = True
 try:
-    import pygit2
+    import pygit2  # type: ignore[import-not-found]
 except ImportError:
     pygit2_available = False
 

--- a/tests/test_git_pygit2.py
+++ b/tests/test_git_pygit2.py
@@ -1,0 +1,42 @@
+# MIT licensed
+# Copyright (c) 2026 Lorenzo Pirritano <lorepirri@gmail.com>
+
+import pytest
+
+# Skip all tests in this file if pygit2 is not installed
+pygit2_available = True
+try:
+  import pygit2
+except ImportError:
+  pygit2_available = False
+
+pytestmark = [
+  pytest.mark.asyncio,
+  pytest.mark.needs_net,
+  pytest.mark.skipif(not pygit2_available, reason="needs pygit2"),
+]
+
+
+async def test_git_pygit2(get_version):
+    assert await get_version("example", {
+        "source": "git_pygit2",
+        "git": "https://gitlab.com/gitlab-org/gitlab-test.git",
+    }) == "v1.1.1"
+
+
+async def test_git_pygit2_commit(get_version):
+    assert await get_version("example", {
+        "source": "git_pygit2",
+        "git": "https://gitlab.com/gitlab-org/gitlab-test.git",
+        "use_commit": True,
+    }) == "ddd0f15ae83993f5cb66a927a28673882e99100b"
+
+
+async def test_git_pygit2_commit_branch(get_version):
+    assert await get_version("example", {
+        "source": "git_pygit2",
+        "git": "https://gitlab.com/gitlab-org/gitlab-test.git",
+        "use_commit": True,
+        "branch": "with-executables",
+    }) == "6b8dc4a827797aa025ff6b8f425e583858a10d4f"
+

--- a/tests/test_git_pygit2.py
+++ b/tests/test_git_pygit2.py
@@ -6,37 +6,54 @@ import pytest
 # Skip all tests in this file if pygit2 is not installed
 pygit2_available = True
 try:
-  import pygit2
+    import pygit2
 except ImportError:
-  pygit2_available = False
+    pygit2_available = False
 
 pytestmark = [
-  pytest.mark.asyncio,
-  pytest.mark.needs_net,
-  pytest.mark.skipif(not pygit2_available, reason="needs pygit2"),
+    pytest.mark.asyncio,
+    pytest.mark.needs_net,
+    pytest.mark.skipif(not pygit2_available, reason="needs pygit2"),
 ]
 
 
 async def test_git_pygit2(get_version):
-    assert await get_version("example", {
-        "source": "git_pygit2",
-        "git": "https://gitlab.com/gitlab-org/gitlab-test.git",
-    }) == "v1.1.1"
+    assert (
+        await get_version(
+            "example",
+            {
+                "source": "git_pygit2",
+                "git": "https://gitlab.com/gitlab-org/gitlab-test.git",
+            },
+        )
+        == "v1.1.1"
+    )
 
 
 async def test_git_pygit2_commit(get_version):
-    assert await get_version("example", {
-        "source": "git_pygit2",
-        "git": "https://gitlab.com/gitlab-org/gitlab-test.git",
-        "use_commit": True,
-    }) == "ddd0f15ae83993f5cb66a927a28673882e99100b"
+    assert (
+        await get_version(
+            "example",
+            {
+                "source": "git_pygit2",
+                "git": "https://gitlab.com/gitlab-org/gitlab-test.git",
+                "use_commit": True,
+            },
+        )
+        == "ddd0f15ae83993f5cb66a927a28673882e99100b"
+    )
 
 
 async def test_git_pygit2_commit_branch(get_version):
-    assert await get_version("example", {
-        "source": "git_pygit2",
-        "git": "https://gitlab.com/gitlab-org/gitlab-test.git",
-        "use_commit": True,
-        "branch": "with-executables",
-    }) == "6b8dc4a827797aa025ff6b8f425e583858a10d4f"
-
+    assert (
+        await get_version(
+            "example",
+            {
+                "source": "git_pygit2",
+                "git": "https://gitlab.com/gitlab-org/gitlab-test.git",
+                "use_commit": True,
+                "branch": "with-executables",
+            },
+        )
+        == "6b8dc4a827797aa025ff6b8f425e583858a10d4f"
+    )


### PR DESCRIPTION
This PR adds a new `git_pygit2` source as an optional alternative backend to the existing `git` source.

Currently, the `git` source relies on the git CLI (`git ls-remote`) to query remote repositories. In some environments (e.g. restricted CI), invoking external binaries is not possible or discouraged.

This implementation uses `pygit2` (libgit2 bindings) to retrieve remote refs without requiring the git executable.

### Details

- New source: `git_pygit2`
- Uses `pygit2` to list remote refs
- Mirrors the behavior of the existing `git` source:
  - tag-based version resolution
  - `use_commit` support
  - branch support
  - returns `gitref` for consistency with other sources

### Dependencies

- Optional dependency via extras: `pip install nvchecker[git_pygit2]`

### Tests

- Added `tests/test_git_pygit2.py`
- Mirrors existing `git` tests
- Skipped automatically if `pygit2` is not available

### Notes

This PR intentionally introduces a **separate source** instead of modifying the existing `git` source behavior.

The broader idea discussed in #316 (multiple backends: git / pygit2 / dulwich) is not fully implemented here.

In particular:

- `dulwich` backend is not included

This keeps the change small and easier to review, while still enabling
non-CLI environments.

---

Closes part of #316