### PR TITLE
git_dulwich: add alternative git source using Dulwich

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -985,7 +985,7 @@ Check Git repository without git CLI using Dulwich
 
   source = "git_dulwich"
 
-This is equivalent to the ``git`` source, but uses Dulwich instead of invoking
+This is similar to the ``git`` source, but uses Dulwich instead of invoking
 the ``git`` executable. It is useful in environments where Python packages can
 be installed but external binaries cannot be executed.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -953,7 +953,7 @@ branch
 
 When this source returns tags (``use_commit`` is not true) it supports :ref:`list options`.
 
-Check Git repository without git CLI
+Check Git repository without git CLI using pygit2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ::
 
@@ -978,6 +978,32 @@ When this source returns tags (``use_commit`` is not true) it supports
 
 .. note::
    An additional dependency ``pygit2`` is required.
+
+Check Git repository without git CLI using Dulwich
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+::
+
+  source = "git_dulwich"
+
+This is equivalent to the ``git`` source, but uses Dulwich instead of invoking
+the ``git`` executable. It is useful in environments where Python packages can
+be installed but external binaries cannot be executed.
+
+git
+  URL of the Git repository.
+
+use_commit
+  Return a commit hash instead of tags.
+
+branch
+  When ``use_commit`` is true, return the commit on the specified branch instead
+  of the default one.
+
+When this source returns tags (``use_commit`` is not true) it supports
+:ref:`list options`.
+
+.. note::
+   An additional dependency ``dulwich`` is required.
 
 Check Mercurial repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nvchecker_source/git_dulwich.py
+++ b/nvchecker_source/git_dulwich.py
@@ -1,0 +1,75 @@
+# MIT licensed
+# Copyright (c) 2026 Lorenzo Pirritano <lorepirri@gmail.com>
+
+import asyncio
+
+import dulwich.client
+
+from nvchecker.api import RichResult, GetVersionError
+
+
+async def _list_remote_refs_async(key):
+    return await asyncio.to_thread(_list_remote_refs, key)
+
+
+def _list_remote_refs(key):
+    git, ref = key
+
+    client, path = dulwich.client.get_transport_and_path(git)
+    result = client.get_refs(path)
+    refs = result.refs
+
+    if ref is None:
+        return refs
+
+    return {k: v for k, v in refs.items() if k.decode() == ref}
+
+
+async def get_version(name, conf, *, cache, keymanager=None):
+    git = conf["git"]
+
+    use_commit = conf.get("use_commit", False)
+    if use_commit:
+        ref = conf.get("branch")
+        if ref is None:
+            ref = "HEAD"
+            gitref = None
+        else:
+            ref = "refs/heads/" + ref
+            gitref = ref
+
+        refs = await cache.get((git, ref), _list_remote_refs_async)
+        if not refs:
+            raise GetVersionError("No ref found in upstream repository.", ref=ref)
+
+        version = next(iter(refs.values())).decode()
+        return RichResult(
+            version=version,
+            revision=version,
+            gitref=gitref,
+        )
+
+    refs = await cache.get((git, None), _list_remote_refs_async)
+
+    versions = []
+    for refname, revision in refs.items():
+        refname = refname.decode()
+        if not refname.startswith("refs/tags/"):
+            continue
+        if refname.endswith("^{}"):
+            continue
+
+        version = refname.removeprefix("refs/tags/")
+        revision = revision.decode()
+        versions.append(
+            RichResult(
+                version=version,
+                revision=revision,
+                gitref=refname,
+            )
+        )
+
+    if not versions:
+        raise GetVersionError("No tag found in upstream repository.")
+
+    return versions

--- a/nvchecker_source/git_dulwich.py
+++ b/nvchecker_source/git_dulwich.py
@@ -3,7 +3,7 @@
 
 import asyncio
 
-import dulwich.client
+import dulwich.client  # type: ignore[import-not-found]
 
 from nvchecker.api import RichResult, GetVersionError
 

--- a/sample_config.toml
+++ b/sample_config.toml
@@ -21,6 +21,10 @@ github = "lilydjwg/nvchecker"
 source = "git_pygit2"
 git = "https://gitlab.com/gitlab-org/gitlab-test.git"
 
+[gitlab-test-dulwich]
+source = "git_dulwich"
+git = "https://gitlab.com/gitlab-org/gitlab-test.git"
+
 [ssed]
 source = "regex"
 regex = "The current version is ([\\d.]+)\\."

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,8 @@ jq =
   jq
 git_pygit2 =
   pygit2
+git_dulwich =
+  dulwich
 
 [options.entry_points]
 console_scripts =

--- a/tests/test_git_dulwich.py
+++ b/tests/test_git_dulwich.py
@@ -5,7 +5,7 @@ import pytest
 
 dulwich_available = True
 try:
-    import dulwich
+    import dulwich  # type: ignore[import-not-found]
 except ImportError:
     dulwich_available = False
 

--- a/tests/test_git_dulwich.py
+++ b/tests/test_git_dulwich.py
@@ -1,0 +1,58 @@
+# MIT licensed
+# Copyright (c) 2026 Lorenzo Pirritano <lorepirri@gmail.com>
+
+import pytest
+
+dulwich_available = True
+try:
+    import dulwich
+except ImportError:
+    dulwich_available = False
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.needs_net,
+    pytest.mark.skipif(not dulwich_available, reason="needs dulwich"),
+]
+
+
+async def test_git_dulwich(get_version):
+    assert (
+        await get_version(
+            "example",
+            {
+                "source": "git_dulwich",
+                "git": "https://gitlab.com/gitlab-org/gitlab-test.git",
+            },
+        )
+        == "v1.1.1"
+    )
+
+
+async def test_git_dulwich_commit(get_version):
+    assert (
+        await get_version(
+            "example",
+            {
+                "source": "git_dulwich",
+                "git": "https://gitlab.com/gitlab-org/gitlab-test.git",
+                "use_commit": True,
+            },
+        )
+        == "ddd0f15ae83993f5cb66a927a28673882e99100b"
+    )
+
+
+async def test_git_dulwich_commit_branch(get_version):
+    assert (
+        await get_version(
+            "example",
+            {
+                "source": "git_dulwich",
+                "git": "https://gitlab.com/gitlab-org/gitlab-test.git",
+                "use_commit": True,
+                "branch": "with-executables",
+            },
+        )
+        == "6b8dc4a827797aa025ff6b8f425e583858a10d4f"
+    )


### PR DESCRIPTION
This PR adds a new `git_dulwich` source as an optional alternative backend to the existing `git` source.

Currently, the `git` source relies on the git CLI (`git ls-remote`) to query remote repositories. In some environments (e.g. restricted CI), invoking external binaries is not possible or discouraged.

This implementation uses Dulwich (pure Python) to retrieve remote refs without requiring the git executable.

### Details

- New source: `git_dulwich`
- Uses Dulwich to list remote refs
- Mirrors the behavior of the existing `git` source:
  - tag-based version resolution
  - `use_commit` support
  - branch support
  - returns `gitref` for consistency with other sources

### Dependencies

- Optional dependency via extras:
    ```
    pip install nvchecker[git_dulwich]
    ```
    

### Tests

- Added `tests/test_git_dulwich.py`
- Mirrors existing `git` and `git_pygit2` tests
- Skipped automatically if `dulwich` is not available

### Notes

This PR follows the approach discussed in #316 and subsequent comments:

- alternative implementations are exposed as **separate explicit sources**
- no backend auto-selection is introduced
- the existing `git` source remains unchanged

This keeps behavior predictable and avoids making backend selection part of the stable API.

This PR is intended to complement the existing `git_pygit2` implementation,
providing a pure-Python alternative.

Common logic between implementations may be extracted in a follow-up PR if useful.

---

This PR is currently stacked on top of #318 (`git_pygit2`) and will show both changes until #318 is merged.

After #318 is merged, I’ll rebase this branch on `master` so the diff only contains the Dulwich source.

---

Part of #316