### PR TITLE
git_pygit2: support older pygit2 versions

### DIFF
--- a/nvchecker_source/git_pygit2.py
+++ b/nvchecker_source/git_pygit2.py
@@ -13,13 +13,20 @@ async def _list_remote_refs_async(key):
     return await asyncio.to_thread(_list_remote_refs, key)
 
 
+def _list_heads(remote):
+    try:
+        return remote.list_heads()
+    except AttributeError:
+        return remote.ls_remotes()
+
+
 def _list_remote_refs(key):
     git, ref = key
 
     with tempfile.TemporaryDirectory() as tmpdir:
         repo = pygit2.init_repository(tmpdir, bare=True)
         remote = repo.remotes.create_anonymous(git)
-        refs = remote.list_heads()
+        refs = _list_heads(remote)
 
     if ref is None:
         return refs


### PR DESCRIPTION
The initial `git_pygit2` implementation used `Remote.list_heads()`.

However, older pygit2 versions still expose the older `ls_remotes()` API instead.

This caused failures in environments using older pygit2 releases (for example Python 3.9 CI jobs).

This PR adds a small compatibility fallback:

- prefer `Remote.list_heads()`
- fallback to `Remote.ls_remotes()` when unavailable

No behavior changes intended besides compatibility with older pygit2 versions.

- Python `3.9`  -> `pygit2 1.15.1` -> no `Remote.list_heads()`
- Python `3.10` -> `pygit2 1.18.2` -> `Remote.list_heads()` exists

This is a follow-up PR to #318 .