### PR TITLE
git_pygit2: support older pygit2 remote ref shape

### DIFF
--- a/nvchecker_source/git_pygit2.py
+++ b/nvchecker_source/git_pygit2.py
@@ -3,21 +3,38 @@
 
 import asyncio
 import tempfile
+from dataclasses import dataclass
+from typing import Any
 
 import pygit2  # type: ignore[import-not-found]
 
-from nvchecker.api import RichResult, GetVersionError
+from nvchecker.api import GetVersionError, RichResult
+
+
+@dataclass(frozen=True)
+class RemoteRef:
+    name: str
+    oid: Any
 
 
 async def _list_remote_refs_async(key):
     return await asyncio.to_thread(_list_remote_refs, key)
 
 
+def _normalize_ref(ref):
+    if isinstance(ref, dict):
+        return RemoteRef(name=ref["name"], oid=ref["oid"])
+
+    return RemoteRef(name=ref.name, oid=ref.oid)
+
+
 def _list_heads(remote):
-    try:
-        return remote.list_heads()
-    except AttributeError:
-        return remote.ls_remotes()
+    if hasattr(remote, "list_heads"):
+        refs = remote.list_heads()
+    else:
+        refs = remote.ls_remotes()
+
+    return [_normalize_ref(ref) for ref in refs]
 
 
 def _list_remote_refs(key):

--- a/tests/test_git_pygit2.py
+++ b/tests/test_git_pygit2.py
@@ -17,6 +17,45 @@ pytestmark = [
 ]
 
 
+class OldRemote:
+    def ls_remotes(self):
+        return [
+            {"name": "refs/tags/v1.0", "oid": "abc123"},
+            {"name": "refs/heads/main", "oid": "def456"},
+        ]
+
+
+class NewRef:
+    name = "refs/tags/v1.0"
+    oid = "abc123"
+
+
+class NewRemote:
+    def list_heads(self):
+        return [NewRef()]
+
+
+async def test_git_pygit2_list_heads_old_pygit2_shape():
+    from nvchecker_source.git_pygit2 import _list_heads
+
+    refs = _list_heads(OldRemote())
+
+    assert refs[0].name == "refs/tags/v1.0"
+    assert refs[0].oid == "abc123"
+
+    assert refs[1].name == "refs/heads/main"
+    assert refs[1].oid == "def456"
+
+
+async def test_git_pygit2_list_heads_new_pygit2_shape():
+    from nvchecker_source.git_pygit2 import _list_heads
+
+    refs = _list_heads(NewRemote())
+
+    assert refs[0].name == "refs/tags/v1.0"
+    assert refs[0].oid == "abc123"
+
+
 async def test_git_pygit2(get_version):
     assert (
         await get_version(


### PR DESCRIPTION
## Summary

Fix `git_pygit2` compatibility with older pygit2 versions selected on Python 3.9.

pygit2 1.15.1 does not provide `Remote.list_heads()`. It only provides `Remote.ls_remotes()`, whose returned refs are dict-like rather than objects exposing `.name` / `.oid`.

This normalizes remote refs at the boundary so the rest of the source can keep using a single internal `.name` / `.oid` representation.

Follow-up to #321 

## Testing

Tested with both old and new pygit2 environments:

- Python `3.9.23` + `pygit2 1.15.1`
- Python `3.11.15` + `pygit2 1.19.2`
