### PR TITLE
git_dulwich: pass default dulwich config to transport

### DIFF
--- a/nvchecker_source/git_dulwich.py
+++ b/nvchecker_source/git_dulwich.py
@@ -4,6 +4,7 @@
 import asyncio
 
 import dulwich.client  # type: ignore[import-not-found]
+from dulwich.config import StackedConfig  # type: ignore[import-not-found]
 
 from nvchecker.api import RichResult, GetVersionError
 
@@ -15,7 +16,8 @@ async def _list_remote_refs_async(key):
 def _list_remote_refs(key):
     git, ref = key
 
-    client, path = dulwich.client.get_transport_and_path(git)
+    config = StackedConfig.default()
+    client, path = dulwich.client.get_transport_and_path(git, config=config)
     result = client.get_refs(path)
     refs = result.refs
 


### PR DESCRIPTION
## Summary

Pass the default Dulwich config to `get_transport_and_path()` in the `git_dulwich` source.

This improves compatibility with standard Git configuration handling when using Dulwich transports.

## What this fixes

Before this change, the `git_dulwich` source ignored several Git configuration settings because no Dulwich config object was provided to the transport layer.

With this patch, Dulwich now respects settings from the default Git config stack, including:

* `http.proxy`
* `http.sslCAInfo`

Example:

```bash
git config --global http.proxy http://127.0.0.1:9
```

After this patch, `git_dulwich` correctly attempts to use the configured proxy.

Likewise:

```bash
git config --global http.sslCAInfo /tmp/nonexistent-ca.pem
```

is now respected by the transport layer.

## What this does NOT solve

This PR intentionally keeps the scope small.

It does not add custom proxy handling or SSL configuration logic inside nvchecker itself.

In particular, this PR does not address:

* environment-variable-only proxy handling

  * e.g. `HTTPS_PROXY`, `HTTP_PROXY`
* custom CA environment variables

  * e.g. `REQUESTS_CA_BUNDLE`
* urllib3-specific transport customization
* authentication ergonomics or credential helpers

The goal is only to allow Dulwich to use its normal default configuration behavior.

## Implementation

The change simply passes:

```python
config = StackedConfig.default()
```

to:

```python
dulwich.client.get_transport_and_path(...)
```

allowing Dulwich to load and apply its standard Git configuration stack.
