### PR TITLE
tests: bump expected pkgver in test_pacman

### DIFF
--- a/tests/test_pacman.py
+++ b/tests/test_pacman.py
@@ -13,7 +13,7 @@ pytestmark = [pytest.mark.asyncio,
 async def test_pacman(get_version):
     assert await get_version("base", {
         "source": "pacman",
-    }) == "3-2"
+    }) == "3-3"
 
 async def test_pacman_strip_release(get_version):
     assert await get_version("base", {


### PR DESCRIPTION
Follow-up to a19c114 (Bump archlinux base 3-3 in test_archpkg test, 2026-02-23).