### PR TITLE
git_dulwich: support HTTP authentication via `username` and `password_key`

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -993,12 +993,26 @@ This source does not support proxy environment variables currently.
 git
   URL of the Git repository.
 
+username
+  Username to use for HTTP authentication.
+
+password_key
+  Key name used to retrieve the password or access token from the configured
+  keyfile.
+
 use_commit
   Return a commit hash instead of tags.
 
 branch
   When ``use_commit`` is true, return the commit on the specified branch instead
   of the default one.
+
+Example for a private GitHub repository::
+
+  source = "git_dulwich"
+  git = "https://github.com/example/private-repo.git"
+  username = "x-access-token"
+  password_key = "github"
 
 When this source returns tags (``use_commit`` is not true) it supports
 :ref:`list options`.

--- a/nvchecker_source/git_dulwich.py
+++ b/nvchecker_source/git_dulwich.py
@@ -45,7 +45,7 @@ def _list_remote_refs(
         username=username,
         password=password,
     )
-    result = client.get_refs(path)  # type: ignore[arg-type]
+    result = client.get_refs(path)
     refs = cast(Dict[bytes, bytes], result.refs)
 
     if ref is None:

--- a/nvchecker_source/git_dulwich.py
+++ b/nvchecker_source/git_dulwich.py
@@ -1,25 +1,52 @@
 # MIT licensed
-# Copyright (c) 2026 Lorenzo Pirritano <lorepirri@gmail.com>
+# Copyright (c) 2026 Lorenzo Pirritano <6698585+lorepirri@users.noreply.github.com>
 
 import asyncio
+from collections.abc import Hashable
+from typing import Dict, List, Optional, Tuple, Union, cast
 
 import dulwich.client  # type: ignore[import-not-found]
 from dulwich.config import StackedConfig  # type: ignore[import-not-found]
 
-from nvchecker.api import RichResult, GetVersionError
+from nvchecker.api import (
+    AsyncCache,
+    Entry,
+    GetVersionError,
+    KeyManager,
+    RichResult,
+    VersionResult,
+)
 
 
-async def _list_remote_refs_async(key):
-    return await asyncio.to_thread(_list_remote_refs, key)
+RemoteRefsKey = Tuple[
+    str,
+    Optional[str],
+    Optional[str],
+    Optional[str],
+]
 
 
-def _list_remote_refs(key):
-    git, ref = key
+async def _list_remote_refs_async(
+    key: Hashable,
+) -> Dict[bytes, bytes]:
+    typed_key = cast(RemoteRefsKey, key)
+    return await asyncio.to_thread(_list_remote_refs, typed_key)
+
+
+def _list_remote_refs(
+    key: RemoteRefsKey,
+) -> Dict[bytes, bytes]:
+    git, ref, username, password = key
 
     config = StackedConfig.default()
-    client, path = dulwich.client.get_transport_and_path(git, config=config)
-    result = client.get_refs(path)
-    refs = result.refs
+    client, path = dulwich.client.get_transport_and_path(
+        git,
+        config=config,
+        username=username,
+        password=password,
+    )
+    result = client.get_refs(path)  # type: ignore[arg-type]
+    refs = cast(Dict[bytes, bytes], result.refs)
 
     if ref is None:
         return refs
@@ -27,8 +54,18 @@ def _list_remote_refs(key):
     return {k: v for k, v in refs.items() if k.decode() == ref}
 
 
-async def get_version(name, conf, *, cache, keymanager=None):
+async def get_version(
+    name: str,
+    conf: Entry,
+    *,
+    cache: AsyncCache,
+    keymanager: KeyManager,
+) -> VersionResult:
     git = conf["git"]
+
+    username = conf.get("username")
+    password_key = conf.get("password_key")
+    password = keymanager.get_key(password_key) if password_key is not None else None
 
     use_commit = conf.get("use_commit", False)
     if use_commit:
@@ -40,9 +77,15 @@ async def get_version(name, conf, *, cache, keymanager=None):
             ref = "refs/heads/" + ref
             gitref = ref
 
-        refs = await cache.get((git, ref), _list_remote_refs_async)
+        refs = await cache.get(
+            (git, ref, username, password),
+            _list_remote_refs_async,
+        )
         if not refs:
-            raise GetVersionError("No ref found in upstream repository.", ref=ref)
+            raise GetVersionError(
+                "No ref found in upstream repository.",
+                ref=ref,
+            )
 
         version = next(iter(refs.values())).decode()
         return RichResult(
@@ -51,9 +94,12 @@ async def get_version(name, conf, *, cache, keymanager=None):
             gitref=gitref,
         )
 
-    refs = await cache.get((git, None), _list_remote_refs_async)
+    refs = await cache.get(
+        (git, None, username, password),
+        _list_remote_refs_async,
+    )
 
-    versions = []
+    versions: List[Union[str, RichResult]] = []
     for refname, revision in refs.items():
         refname = refname.decode()
         if not refname.startswith("refs/tags/"):
@@ -62,11 +108,11 @@ async def get_version(name, conf, *, cache, keymanager=None):
             continue
 
         version = refname.removeprefix("refs/tags/")
-        revision = revision.decode()
+        revision_str = revision.decode()
         versions.append(
             RichResult(
                 version=version,
-                revision=revision,
+                revision=revision_str,
                 gitref=refname,
             )
         )

--- a/tests/test_git_dulwich.py
+++ b/tests/test_git_dulwich.py
@@ -1,22 +1,26 @@
 # MIT licensed
 # Copyright (c) 2026 Lorenzo Pirritano <lorepirri@gmail.com>
 
+from types import SimpleNamespace
+
 import pytest
+
+from nvchecker_source import git_dulwich
 
 dulwich_available = True
 try:
-    import dulwich  # type: ignore[import-not-found]
+    __import__("dulwich")
 except ImportError:
     dulwich_available = False
 
 
 pytestmark = [
     pytest.mark.asyncio,
-    pytest.mark.needs_net,
     pytest.mark.skipif(not dulwich_available, reason="needs dulwich"),
 ]
 
 
+@pytest.mark.needs_net
 async def test_git_dulwich(get_version):
     assert (
         await get_version(
@@ -30,6 +34,7 @@ async def test_git_dulwich(get_version):
     )
 
 
+@pytest.mark.needs_net
 async def test_git_dulwich_commit(get_version):
     assert (
         await get_version(
@@ -44,6 +49,7 @@ async def test_git_dulwich_commit(get_version):
     )
 
 
+@pytest.mark.needs_net
 async def test_git_dulwich_commit_branch(get_version):
     assert (
         await get_version(
@@ -57,3 +63,64 @@ async def test_git_dulwich_commit_branch(get_version):
         )
         == "6b8dc4a827797aa025ff6b8f425e583858a10d4f"
     )
+
+
+async def test_git_dulwich_http_auth(monkeypatch):
+    expected_password = "secret-token"
+
+    class FakeKeyManager:
+        def get_key(self, name):
+            assert name == "private-repository"
+            return expected_password
+
+    class FakeClient:
+        def get_refs(self, path):
+            assert path == "/owner/repository.git"
+            return SimpleNamespace(
+                refs={
+                    b"refs/tags/v1.0.0": b"0123456789abcdef",
+                }
+            )
+
+    def fake_get_transport_and_path(
+        location,
+        *,
+        config,
+        username=None,
+        password=None,
+        **kwargs,
+    ):
+        assert location == "https://example.com/owner/repository.git"
+        assert username == "git-user"
+        assert password == expected_password
+        return FakeClient(), "/owner/repository.git"
+
+    monkeypatch.setattr(
+        git_dulwich.dulwich.client,
+        "get_transport_and_path",
+        fake_get_transport_and_path,
+    )
+
+    class FakeCache:
+        async def get(self, key, callback):
+            assert key == (
+                "https://example.com/owner/repository.git",
+                None,
+                "git-user",
+                expected_password,
+            )
+            return await callback(key)
+
+    result = await git_dulwich.get_version(
+        "example",
+        {
+            "source": "git_dulwich",
+            "git": "https://example.com/owner/repository.git",
+            "username": "git-user",
+            "password_key": "private-repository",
+        },
+        cache=FakeCache(),
+        keymanager=FakeKeyManager(),
+    )
+
+    assert result[0].version == "v1.0.0"

--- a/tests/test_git_dulwich.py
+++ b/tests/test_git_dulwich.py
@@ -5,8 +5,6 @@ from types import SimpleNamespace
 
 import pytest
 
-from nvchecker_source import git_dulwich
-
 dulwich_available = True
 try:
     __import__("dulwich")
@@ -18,6 +16,8 @@ pytestmark = [
     pytest.mark.asyncio,
     pytest.mark.skipif(not dulwich_available, reason="needs dulwich"),
 ]
+
+from nvchecker_source import git_dulwich  # noqa: E402
 
 
 @pytest.mark.needs_net


### PR DESCRIPTION
Close #324

This adds HTTP authentication support to the `git_dulwich` source.

New configuration options:

```toml
username = "x-access-token"
password_key = "github"
````

The password is retrieved through `KeyManager`, while `username` is optional to support different Git servers.

Existing support for credentials embedded in the Git URL is preserved.

Tests cover:

* forwarding `username` and `password` to Dulwich,
* `KeyManager` integration,
* cache key separation by credentials,
* preservation of existing URL-based authentication.

Additionally verified manually against a private GitHub repository:

* valid PAT succeeds,
* invalid PAT is rejected,
* missing credentials are rejected,
* inline URL credentials continue to work.

Unrelated cleanup:

* update the copyright header to use my GitHub noreply email.