### PR TITLE
git_pygit2: support HTTP authentication via `username` and `password_key`

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -953,7 +953,7 @@ branch
 When this source returns tags (``use_commit`` is not true) it supports :ref:`list options`.
 
 Check Git repository without git CLI using pygit2
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ::
 
   source = "git_pygit2"
@@ -965,12 +965,26 @@ packages can be installed but external binaries cannot be executed.
 git
   URL of the Git repository.
 
+username
+  Username to use for HTTP authentication.
+
+password_key
+  Key name used to retrieve the password or access token from the configured
+  keyfile.
+
 use_commit
   Return a commit hash instead of tags.
 
 branch
   When ``use_commit`` is true, return the commit on the specified branch instead
   of the default one.
+
+Example for a private GitHub repository::
+
+  source = "git_pygit2"
+  git = "https://github.com/example/private-repo.git"
+  username = "x-access-token"
+  password_key = "github"
 
 When this source returns tags (``use_commit`` is not true) it supports
 :ref:`list options`.

--- a/nvchecker_source/git_pygit2.py
+++ b/nvchecker_source/git_pygit2.py
@@ -92,6 +92,8 @@ async def get_version(
 
     username = conf.get("username")
     password_key = conf.get("password_key")
+    if (username is None) != (password_key is None):
+        raise GetVersionError("username and password_key must be specified together")
     password = keymanager.get_key(password_key) if password_key is not None else None
 
     use_commit = conf.get("use_commit", False)

--- a/nvchecker_source/git_pygit2.py
+++ b/nvchecker_source/git_pygit2.py
@@ -1,14 +1,30 @@
 # MIT licensed
-# Copyright (c) 2026 Lorenzo Pirritano <lorepirri@gmail.com>
+# Copyright (c) 2026 Lorenzo Pirritano <6698585+lorepirri@users.noreply.github.com>
 
 import asyncio
 import tempfile
+from collections.abc import Hashable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, List, Optional, Tuple, Union, cast
 
 import pygit2  # type: ignore[import-not-found]
 
-from nvchecker.api import GetVersionError, RichResult
+from nvchecker.api import (
+    AsyncCache,
+    Entry,
+    GetVersionError,
+    KeyManager,
+    RichResult,
+    VersionResult,
+)
+
+
+RemoteRefsKey = Tuple[
+    str,
+    Optional[str],
+    Optional[str],
+    Optional[str],
+]
 
 
 @dataclass(frozen=True)
@@ -17,42 +33,66 @@ class RemoteRef:
     oid: Any
 
 
-async def _list_remote_refs_async(key):
-    return await asyncio.to_thread(_list_remote_refs, key)
+async def _list_remote_refs_async(
+    key: Hashable,
+) -> List[RemoteRef]:
+    typed_key = cast(RemoteRefsKey, key)
+    return await asyncio.to_thread(_list_remote_refs, typed_key)
 
 
-def _normalize_ref(ref):
+def _normalize_ref(ref: Any) -> RemoteRef:
     if isinstance(ref, dict):
         return RemoteRef(name=ref["name"], oid=ref["oid"])
 
     return RemoteRef(name=ref.name, oid=ref.oid)
 
 
-def _list_heads(remote):
+def _list_heads(
+    remote: Any,
+    callbacks: Optional[pygit2.RemoteCallbacks] = None,
+) -> List[RemoteRef]:
     if hasattr(remote, "list_heads"):
-        refs = remote.list_heads()
+        refs = remote.list_heads(callbacks=callbacks)
     else:
-        refs = remote.ls_remotes()
+        refs = remote.ls_remotes(callbacks=callbacks)
 
     return [_normalize_ref(ref) for ref in refs]
 
 
-def _list_remote_refs(key):
-    git, ref = key
+def _list_remote_refs(
+    key: RemoteRefsKey,
+) -> List[RemoteRef]:
+    git, ref, username, password = key
+
+    callbacks = None
+    if username is not None and password is not None:
+        callbacks = pygit2.RemoteCallbacks(
+            credentials=pygit2.UserPass(username, password),
+        )
 
     with tempfile.TemporaryDirectory() as tmpdir:
         repo = pygit2.init_repository(tmpdir, bare=True)
         remote = repo.remotes.create_anonymous(git)
-        refs = _list_heads(remote)
+        refs = _list_heads(remote, callbacks)
 
     if ref is None:
         return refs
 
-    return [r for r in refs if r.name == ref]
+    return [remote_ref for remote_ref in refs if remote_ref.name == ref]
 
 
-async def get_version(name, conf, *, cache, keymanager=None):
+async def get_version(
+    name: str,
+    conf: Entry,
+    *,
+    cache: AsyncCache,
+    keymanager: KeyManager,
+) -> VersionResult:
     git = conf["git"]
+
+    username = conf.get("username")
+    password_key = conf.get("password_key")
+    password = keymanager.get_key(password_key) if password_key is not None else None
 
     use_commit = conf.get("use_commit", False)
     if use_commit:
@@ -64,7 +104,10 @@ async def get_version(name, conf, *, cache, keymanager=None):
             ref = "refs/heads/" + ref
             gitref = ref
 
-        refs = await cache.get((git, ref), _list_remote_refs_async)
+        refs = await cache.get(
+            (git, ref, username, password),
+            _list_remote_refs_async,
+        )
         if not refs:
             raise GetVersionError("No ref found in upstream repository.", ref=ref)
 
@@ -75,9 +118,12 @@ async def get_version(name, conf, *, cache, keymanager=None):
             gitref=gitref,
         )
 
-    refs = await cache.get((git, None), _list_remote_refs_async)
+    refs = await cache.get(
+        (git, None, username, password),
+        _list_remote_refs_async,
+    )
 
-    versions = []
+    versions: List[Union[str, RichResult]] = []
     for ref in refs:
         if not ref.name.startswith("refs/tags/"):
             continue

--- a/tests/test_git_pygit2.py
+++ b/tests/test_git_pygit2.py
@@ -3,6 +3,8 @@
 
 import pytest
 
+from nvchecker.api import GetVersionError
+
 # Skip all tests in this file if pygit2 is not installed
 pygit2_available = True
 try:
@@ -162,3 +164,31 @@ async def test_git_pygit2_http_auth(monkeypatch):
     )
 
     assert result[0].version == "v1.0"
+
+
+@pytest.mark.parametrize(
+    "conf",
+    [
+        {
+            "git": "https://example.com/repository.git",
+            "username": "git-user",
+        },
+        {
+            "git": "https://example.com/repository.git",
+            "password_key": "git-password",
+        },
+    ],
+)
+async def test_git_pygit2_http_auth_requires_both_options(conf):
+    from nvchecker_source import git_pygit2
+
+    with pytest.raises(
+        GetVersionError,
+        match="username and password_key must be specified together",
+    ):
+        await git_pygit2.get_version(
+            "test",
+            conf,
+            cache=None,  # type: ignore[arg-type]
+            keymanager=None,  # type: ignore[arg-type]
+        )

--- a/tests/test_git_pygit2.py
+++ b/tests/test_git_pygit2.py
@@ -18,7 +18,8 @@ pytestmark = [
 
 
 class OldRemote:
-    def ls_remotes(self):
+    def ls_remotes(self, callbacks=None):
+        assert callbacks is None
         return [
             {"name": "refs/tags/v1.0", "oid": "abc123"},
             {"name": "refs/heads/main", "oid": "def456"},
@@ -31,7 +32,8 @@ class NewRef:
 
 
 class NewRemote:
-    def list_heads(self):
+    def list_heads(self, callbacks=None):
+        assert callbacks is None
         return [NewRef()]
 
 
@@ -96,3 +98,67 @@ async def test_git_pygit2_commit_branch(get_version):
         )
         == "6b8dc4a827797aa025ff6b8f425e583858a10d4f"
     )
+
+
+async def test_git_pygit2_http_auth(monkeypatch):
+    from nvchecker_source import git_pygit2
+
+    expected_password = "secret-token"
+
+    class FakeKeyManager:
+        def get_key(self, name):
+            assert name == "private-repository"
+            return expected_password
+
+    class FakeRemote:
+        def list_heads(self, callbacks=None):
+            assert callbacks is not None
+
+            credentials = callbacks.credentials
+            assert isinstance(credentials, pygit2.UserPass)
+            # credential_tuple is part of pygit2's public API and is available across
+            # the supported pygit2 versions. Avoid asserting on the private _username
+            # and _password attributes.
+            assert credentials.credential_tuple == (
+                "git-user",
+                expected_password,
+            )
+            return [NewRef()]
+
+    class FakeRemotes:
+        def create_anonymous(self, url):
+            assert url == "https://example.com/owner/repository.git"
+            return FakeRemote()
+
+    class FakeRepo:
+        remotes = FakeRemotes()
+
+    monkeypatch.setattr(
+        git_pygit2.pygit2,
+        "init_repository",
+        lambda path, bare: FakeRepo(),
+    )
+
+    class FakeCache:
+        async def get(self, key, callback):
+            assert key == (
+                "https://example.com/owner/repository.git",
+                None,
+                "git-user",
+                expected_password,
+            )
+            return await callback(key)
+
+    result = await git_pygit2.get_version(
+        "example",
+        {
+            "source": "git_pygit2",
+            "git": "https://example.com/owner/repository.git",
+            "username": "git-user",
+            "password_key": "private-repository",
+        },
+        cache=FakeCache(),
+        keymanager=FakeKeyManager(),
+    )
+
+    assert result[0].version == "v1.0"

--- a/tests/test_git_pygit2.py
+++ b/tests/test_git_pygit2.py
@@ -189,6 +189,6 @@ async def test_git_pygit2_http_auth_requires_both_options(conf):
         await git_pygit2.get_version(
             "test",
             conf,
-            cache=None,  # type: ignore[arg-type]
-            keymanager=None,  # type: ignore[arg-type]
+            cache=None,
+            keymanager=None,
         )


### PR DESCRIPTION
This adds HTTP authentication support to the `git_pygit2` source.

New configuration options:

```toml
username = "x-access-token"
password_key = "github"
```

The password is retrieved through `KeyManager` and passed to pygit2 via `RemoteCallbacks(UserPass(...))`.

Existing support for credentials embedded in the Git URL is preserved.

Tests cover:

* forwarding `username` and `password` to pygit2,
* `KeyManager` integration,
* cache key separation by credentials,
* compatibility with both historical (`ls_remotes`) and current (`list_heads`) pygit2 APIs.

Additionally verified manually against a private GitHub repository:

* valid PAT succeeds,
* invalid PAT is rejected,
* missing credentials are rejected,
* inline URL credentials continue to work.

Unrelated cleanup:

* add type annotations consistent with the `git_dulwich` implementation,
* update the copyright header to use my GitHub noreply email.