### PR TITLE
tests: avoid importing git_dulwich during test collection

### DIFF
--- a/tests/test_git_dulwich.py
+++ b/tests/test_git_dulwich.py
@@ -17,8 +17,6 @@ pytestmark = [
     pytest.mark.skipif(not dulwich_available, reason="needs dulwich"),
 ]
 
-from nvchecker_source import git_dulwich  # noqa: E402
-
 
 @pytest.mark.needs_net
 async def test_git_dulwich(get_version):
@@ -66,6 +64,8 @@ async def test_git_dulwich_commit_branch(get_version):
 
 
 async def test_git_dulwich_http_auth(monkeypatch):
+    from nvchecker_source import git_dulwich
+
     expected_password = "secret-token"
 
     class FakeKeyManager:

--- a/tests/test_git_dulwich.py
+++ b/tests/test_git_dulwich.py
@@ -64,7 +64,6 @@ async def test_git_dulwich_commit_branch(get_version):
 
 
 async def test_git_dulwich_http_auth(monkeypatch):
-
     expected_password = "secret-token"
 
     class FakeKeyManager:

--- a/tests/test_git_dulwich.py
+++ b/tests/test_git_dulwich.py
@@ -7,7 +7,7 @@ import pytest
 
 dulwich_available = True
 try:
-    __import__("dulwich")
+    from nvchecker_source import git_dulwich
 except ImportError:
     dulwich_available = False
 
@@ -64,7 +64,6 @@ async def test_git_dulwich_commit_branch(get_version):
 
 
 async def test_git_dulwich_http_auth(monkeypatch):
-    from nvchecker_source import git_dulwich
 
     expected_password = "secret-token"
 


### PR DESCRIPTION
The HTTP authentication test imports git_dulwich at module scope.

When Dulwich is not installed, importing `nvchecker_source.git_dulwich` fails during test collection, so the `pytest.mark.skipif` never takes effect.

Move the import into the ~test that needs it~ _try block_, matching the pattern already used by `test_git_pygit2.py`. This allows the file to be collected and skipped correctly when the optional dependency is unavailable.