### PR TITLE
Preserve `RichResult` metadata during normalization

### DIFF
--- a/nvchecker/core.py
+++ b/nvchecker/core.py
@@ -360,9 +360,8 @@ def _process_result(r: RawResult) -> Union[RichResult, Exception]:
   conf = r.conf
   name = r.name
 
-  url = None
-  revision = None
-  gitref = None
+  result = None
+
   if isinstance(version, GetVersionError):
     kw = version.kwargs
     kw['name'] = name
@@ -375,15 +374,11 @@ def _process_result(r: RawResult) -> Union[RichResult, Exception]:
   elif isinstance(version, list):
     version_str = apply_list_options(version, conf, name)
     if isinstance(version_str, RichResult):
-      url = version_str.url
-      gitref = version_str.gitref
-      revision = version_str.revision
+      result = version_str
       version_str = version_str.version
   elif isinstance(version, RichResult):
+    result = version
     version_str = version.version
-    url = version.url
-    gitref = version.gitref
-    revision = version.revision
   else:
     version_str = version
 
@@ -392,12 +387,9 @@ def _process_result(r: RawResult) -> Union[RichResult, Exception]:
 
     try:
       version_str = substitute_version(version_str, conf)
-      return RichResult(
-        version = version_str,
-        url = url,
-        gitref = gitref,
-        revision = revision,
-      )
+      if result is None:
+        return RichResult(version=version_str)
+      return dataclasses.replace(result, version=version_str)
     except (ValueError, re.error) as e:
       logger.exception('error occurred in version substitutions', name=name)
       return e

--- a/nvchecker/util.py
+++ b/nvchecker/util.py
@@ -52,7 +52,9 @@ if sys.version_info[:2] >= (3, 10):
     gitref: Optional[str] = None
     revision: Optional[str] = None
     url: Optional[str] = None
+    # Creation/publication time of the selected version object, if applicable.
     creation_time: Optional[str] = None
+    # Creation time of the underlying revision object, if applicable.
     revision_creation_time: Optional[str] = None
 
     def __str__(self):
@@ -64,7 +66,9 @@ else:
     gitref: Optional[str] = None
     revision: Optional[str] = None
     url: Optional[str] = None
+    # Creation/publication time of the selected version object, if applicable.
     creation_time: Optional[str] = None
+    # Creation time of the underlying revision object, if applicable.
     revision_creation_time: Optional[str] = None
 
     def __str__(self):

--- a/nvchecker/util.py
+++ b/nvchecker/util.py
@@ -52,6 +52,8 @@ if sys.version_info[:2] >= (3, 10):
     gitref: Optional[str] = None
     revision: Optional[str] = None
     url: Optional[str] = None
+    creation_time: Optional[str] = None
+    revision_creation_time: Optional[str] = None
 
     def __str__(self):
       return self.version
@@ -62,6 +64,8 @@ else:
     gitref: Optional[str] = None
     revision: Optional[str] = None
     url: Optional[str] = None
+    creation_time: Optional[str] = None
+    revision_creation_time: Optional[str] = None
 
     def __str__(self):
       return self.version

--- a/tests/test_rich_result.py
+++ b/tests/test_rich_result.py
@@ -1,0 +1,123 @@
+import json
+
+from nvchecker.core import _process_result, json_encode
+from nvchecker.util import RawResult, RichResult
+
+
+def test_timestamps_survive_list_selection():
+    result = _process_result(
+        RawResult(
+            "test",
+            [
+                RichResult(
+                    version="1.0",
+                    creation_time="2026-07-20T12:00:00Z",
+                    revision_creation_time="2026-07-19T10:00:00Z",
+                ),
+                RichResult(
+                    version="2.0",
+                    creation_time="2026-07-22T12:00:00Z",
+                    revision_creation_time="2026-07-21T10:00:00Z",
+                ),
+            ],
+            {},
+        )
+    )
+
+    assert result == RichResult(
+        version="2.0",
+        creation_time="2026-07-22T12:00:00Z",
+        revision_creation_time="2026-07-21T10:00:00Z",
+    )
+
+
+def test_timestamps_serialize_when_present():
+    result = json.loads(
+        json.dumps(
+            RichResult(
+                version="1.2.3",
+                creation_time="2026-07-22T12:00:00Z",
+                revision_creation_time="2026-07-21T10:00:00Z",
+            ),
+            default=json_encode,
+        )
+    )
+
+    assert result == {
+        "version": "1.2.3",
+        "creation_time": "2026-07-22T12:00:00Z",
+        "revision_creation_time": "2026-07-21T10:00:00Z",
+    }
+
+
+def test_creation_time_omitted_when_none():
+    result = json.loads(
+        json.dumps(
+            RichResult(
+                version="1.2.3",
+                revision_creation_time="2026-07-21T10:00:00Z",
+            ),
+            default=json_encode,
+        )
+    )
+
+    assert result == {
+        "version": "1.2.3",
+        "revision_creation_time": "2026-07-21T10:00:00Z",
+    }
+
+
+def test_revision_creation_time_omitted_when_none():
+    result = json.loads(
+        json.dumps(
+            RichResult(
+                version="1.2.3",
+                creation_time="2026-07-22T12:00:00Z",
+            ),
+            default=json_encode,
+        )
+    )
+
+    assert result == {
+        "version": "1.2.3",
+        "creation_time": "2026-07-22T12:00:00Z",
+    }
+
+
+def test_timestamps_omitted_when_none():
+    result = json.loads(
+        json.dumps(
+            RichResult(version="1.2.3"),
+            default=json_encode,
+        )
+    )
+
+    assert result == {
+        "version": "1.2.3",
+    }
+
+
+def test_rich_result_metadata_survives_normalization():
+    result = _process_result(
+        RawResult(
+            "test",
+            RichResult(
+                version="v1.2.3",
+                url="https://example.com/release",
+                gitref="refs/tags/v1.2.3",
+                revision="abcdef",
+                creation_time="2026-07-22T12:00:00Z",
+                revision_creation_time="2026-07-21T10:00:00Z",
+            ),
+            {"prefix": "v"},
+        )
+    )
+
+    assert result == RichResult(
+        version="1.2.3",
+        url="https://example.com/release",
+        gitref="refs/tags/v1.2.3",
+        revision="abcdef",
+        creation_time="2026-07-22T12:00:00Z",
+        revision_creation_time="2026-07-21T10:00:00Z",
+    )


### PR DESCRIPTION
Close #320 

This PR extends `RichResult` with two optional timestamp fields:

* `creation_time`
* `revision_creation_time`

It also updates `_process_result()` to preserve all `RichResult` metadata when applying version normalization.

Previously, `_process_result()` reconstructed a new `RichResult` after normalization and manually copied a fixed set of metadata fields (`url`, `gitref`, and `revision`). This PR instead keeps the original `RichResult` and uses `dataclasses.replace()` to update only the normalized version string, preserving the remaining fields automatically.

### Tests

Added tests covering:

* preservation of metadata during version normalization;
* preservation of timestamps when selecting the newest entry from a list of `RichResult`s;
* JSON serialization of the new timestamp fields;
* omission of optional timestamp fields when they are `None`.

This change is intended as infrastructure for sources that will expose release and revision timestamps in future follow-up PRs.
