### PR TITLE
tests: skip rpmrepo tests when optional dependencies are unavailable

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -930,8 +930,9 @@ arch
 This source supports :ref:`list options`.
 
 .. note::
-   An additional dependency "lxml" is required.
-   You can use ``pip install 'nvchecker[rpmrepo]'``.
+   The additional dependency ``lxml`` is required. On Python versions earlier
+   than 3.14, ``zstandard`` is required as well.
+   You can install them with ``pip install 'nvchecker[rpmrepo]'``.
 
 Check Git repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_rpmrepo.py
+++ b/tests/test_rpmrepo.py
@@ -2,7 +2,26 @@
 # Copyright (c) 2024 Jakub Ružička <jru@debian.org>, et al.
 
 import pytest
-pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]
+
+rpmrepo_deps_available = True
+try:
+    __import__("lxml.etree")
+    try:
+        __import__("compression.zstd")
+    except ImportError:
+        __import__("zstandard")
+except ImportError:
+    rpmrepo_deps_available = False
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.needs_net,
+    pytest.mark.skipif(
+        not rpmrepo_deps_available,
+        reason="needs rpmrepo dependencies",
+    ),
+]
+
 
 async def test_rpmrepo_fedora(get_version):
     ver = await get_version("knot_fedora-39", {


### PR DESCRIPTION
The rpmrepo source depends on optional packages (`lxml` and, on Python <3.14, `zstandard`).

Unlike other optional source tests (e.g. `jq`, `git_dulwich`, `git_pygit2`), `test_rpmrepo.py` always attempted to run, causing failures in environments where the optional dependencies were not installed.

This change follows the existing pattern by skipping the module when the rpmrepo dependencies are unavailable.

It also updates the documentation note for the `rpmrepo` source to mention the Python-version-specific `zstandard` dependency.