### PR TITLE
tests: replace stale container test fixture

### DIFF
--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -16,12 +16,12 @@ async def test_container(get_version):
   }) == "linux"
 
 async def test_container_with_tag(get_version):
-  update_time = await get_version("bitnami/mongodb:5.0", {
+  update_time = await get_version("amd64/busybox:1.31.1", {
     "source": "container",
-    "container": "bitnami/mongodb:5.0",
+    "container": "amd64/busybox:1.31.1",
   })
   # the update time is changing occasionally, so we can not compare the exact time, otherwise the test will be failed in the future
-  assert datetime.date.fromisoformat(update_time.split('T')[0]) > datetime.date(2023, 12, 1)
+  assert datetime.date.fromisoformat(update_time.split('T')[0]) > datetime.date(2020, 1, 1)
 
 async def test_container_with_tag_and_multi_arch(get_version):
   update_time = await get_version("hello-world:linux", {


### PR DESCRIPTION
Close #310

`bitnami/mongodb:5.0` is no longer available on Docker Hub and now returns 404, causing `test_container_with_tag` to fail.

This replaces it with `amd64/busybox:1.31.1`, which is a stable single-architecture schema-2 manifest. The test continues to exercise the direct manifest path, while `test_container_with_tag_and_multi_arch` still covers manifest lists.
