### PR TITLE
Include serialized `RichResult` in updated log events

### DIFF
--- a/nvchecker/core.py
+++ b/nvchecker/core.py
@@ -167,10 +167,16 @@ def write_verfile(file: Path, versions: ResultData) -> None:
   ) + '\n'
   safe_overwrite(file, data)
 
+def _rich_result_to_dict(result: RichResult) -> Dict[str, Any]:
+  return {
+    k: v
+    for k, v in dataclasses.asdict(result).items()
+    if v is not None
+  }
+
 def json_encode(obj):
   if isinstance(obj, RichResult):
-    d = {k: v for k, v in dataclasses.asdict(obj).items() if v is not None}
-    return d
+    return _rich_result_to_dict(obj)
   raise TypeError(obj)
 
 class Options(NamedTuple):
@@ -423,6 +429,7 @@ def check_version_update(
       revision = r.revision,
       old_version = oldver,
       url = r.url,
+      rich_result = _rich_result_to_dict(r),
     )
   else:
     # provide visible user feedback if it was the only entry

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,57 @@
+# MIT licensed
+# Copyright (c) 2026 lilydjwg <lilydjwg@gmail.com>, et al.
+
+from unittest.mock import patch
+
+from nvchecker.core import check_version_update
+from nvchecker.util import RichResult
+
+
+def test_updated_event_contains_rich_result():
+    with patch("nvchecker.core.logger.info") as info:
+        check_version_update(
+            oldvers={},
+            name="example",
+            r=RichResult(
+                version="1.2.3",
+                revision="abc123",
+                url="https://example.invalid",
+                gitref="refs/tags/v1.2.3",
+            ),
+            verbose=False,
+        )
+
+    info.assert_called_once()
+
+    _, kwargs = info.call_args
+
+    assert kwargs["name"] == "example"
+    assert kwargs["version"] == "1.2.3"
+    assert kwargs["revision"] == "abc123"
+    assert kwargs["old_version"] is None
+    assert kwargs["url"] == "https://example.invalid"
+
+    assert kwargs["rich_result"] == {
+        "version": "1.2.3",
+        "revision": "abc123",
+        "url": "https://example.invalid",
+        "gitref": "refs/tags/v1.2.3",
+    }
+
+
+def test_updated_event_omits_none_rich_result_fields():
+    with patch("nvchecker.core.logger.info") as info:
+        check_version_update(
+            oldvers={},
+            name="example",
+            r=RichResult(version="1.2.3"),
+            verbose=False,
+        )
+
+    info.assert_called_once()
+
+    _, kwargs = info.call_args
+
+    assert kwargs["rich_result"] == {
+        "version": "1.2.3",
+    }


### PR DESCRIPTION
Close #338 

Add a `rich_result` field to the structured `updated` event.

The field contains the serialized `RichResult`, exposing metadata such as `gitref` while keeping the existing top-level fields unchanged.

The same serialization helper is shared with version-file JSON output, so future `RichResult` fields are included automatically.