### PR TITLE
GitHub: populate `RichResult` timestamp metadata

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -479,6 +479,26 @@ To set an authorization token, you can set:
 This source supports :ref:`list options` when ``use_max_tag`` or
 ``use_max_release`` is set.
 
+RichResult metadata
+~~~~~~~~~~~~~~~~~~~
+
+When available from the existing GitHub API responses, this source populates
+the following optional ``RichResult`` fields. No additional API requests are
+issued solely to retrieve timestamp information.
+
+==================================== ====================== =============================================
+Mode                                 creation_time          revision_creation_time
+==================================== ====================== =============================================
+default commit/path                  —                      commit timestamp
+``use_latest_release``               release publish time   —
+``use_max_release``                  release publish time   —
+``use_latest_release`` +
+``include_prereleases``              release publish time   commit timestamp
+``use_latest_tag``                   —                      tag creation time (annotated tags) or commit
+                                                            timestamp (lightweight tags)
+``use_max_tag``                      —                      —
+==================================== ====================== =============================================
+
 Check Gitea
 ~~~~~~~~~~~
 ::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -489,14 +489,14 @@ issued solely to retrieve timestamp information.
 ==================================== ====================== =============================================
 Mode                                 creation_time          revision_creation_time
 ==================================== ====================== =============================================
-default commit/path                  —                      commit timestamp
-``use_latest_release``               release publish time   —
-``use_max_release``                  release publish time   —
+default commit/path                  -                      commit timestamp
+``use_latest_release``               release publish time   -
+``use_max_release``                  release publish time   -
 ``use_latest_release`` +
 ``include_prereleases``              release publish time   commit timestamp
-``use_latest_tag``                   —                      tag creation time (annotated tags) or commit
+``use_latest_tag``                   -                      tag creation time (annotated tags) or commit
                                                             timestamp (lightweight tags)
-``use_max_tag``                      —                      —
+``use_max_tag``                      -                      -
 ==================================== ====================== =============================================
 
 Check Gitea

--- a/nvchecker_source/github.py
+++ b/nvchecker_source/github.py
@@ -57,7 +57,16 @@ QUERY_LATEST_TAG = '''
         node {{
           name
           target {{
+            __typename
             oid
+            ... on Commit {{
+              committedDate
+            }}
+            ... on Tag {{
+              tagger {{
+                date
+              }}
+            }}
           }}
         }}
       }}
@@ -74,11 +83,13 @@ QUERY_LATEST_RELEASE_WITH_PRERELEASES = '''
         node {{
           name
           url
+          publishedAt
           tag {{
             name
           }}
           tagCommit {{
             oid
+            committedDate
           }}
         }}
       }}
@@ -111,13 +122,26 @@ async def get_latest_tag(key: Tuple[str, str, str, str]) -> RichResult:
   if not refs:
     raise GetVersionError('no tag found')
 
-  version = refs[0]['node']['name']
-  revision = refs[0]['node']['target']['oid']
+  node = refs[0]['node']
+  target = node['target']
+
+  if target['__typename'] == 'Commit':
+    revision_creation_time = target.get('committedDate')
+  elif target['__typename'] == 'Tag':
+    tagger = target.get('tagger')
+    revision_creation_time = (
+      tagger.get('date') if tagger is not None else None
+    )
+  else:
+    revision_creation_time = None
+
+  version = node['name']
   return RichResult(
     version = version,
     gitref = f"refs/tags/{version}",
-    revision = revision,
+    revision = target['oid'],
     url = f'https://github.com/{repo}/releases/tag/{version}',
+    revision_creation_time = revision_creation_time,
   )
 
 async def get_latest_release_with_prereleases(key: Tuple[str, str, str, str]) -> RichResult:
@@ -143,17 +167,21 @@ async def get_latest_release_with_prereleases(key: Tuple[str, str, str, str]) ->
   if not refs:
     raise GetVersionError('no release found')
 
-  tag_name = refs[0]['node']['tag']['name']
+  node = refs[0]['node']
+  tag_name = node['tag']['name']
+
   if use_release_name:
-    version = refs[0]['node']['name']
+    version = node['name']
   else:
     version = tag_name
 
   return RichResult(
     version = version,
     gitref = f"refs/tags/{tag_name}",
-    revision = refs[0]['node']['tagCommit']['oid'],
-    url = refs[0]['node']['url'],
+    revision = node['tagCommit']['oid'],
+    url = node['url'],
+    creation_time = node.get('publishedAt'),
+    revision_creation_time = node['tagCommit'].get('committedDate'),
   )
 
 async def get_version_real(
@@ -234,6 +262,7 @@ async def get_version_real(
         version = ref['name'] if use_release_name else ref['tag_name'],
         gitref = f"refs/tags/{ref['tag_name']}",
         url = ref['html_url'],
+        creation_time = ref.get('published_at'),
       ) for ref in data if include_prereleases or not ref['prerelease']
     ]
     if not releases:
@@ -253,6 +282,7 @@ async def get_version_real(
       version = version,
       gitref = f"refs/tags/{data['tag_name']}",
       url = data['html_url'],
+      creation_time = data.get('published_at'),
     )
 
   else:
@@ -260,6 +290,7 @@ async def get_version_real(
       # YYYYMMDD.HHMMSS
       version = data[0]['commit']['committer']['date'].rstrip('Z').replace('-', '').replace(':', '').replace('T', '.'),
       revision = data[0]['sha'],
+      revision_creation_time = data[0]['commit']['committer']['date'],
       url = data[0]['html_url'],
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,9 +24,9 @@ from nvchecker.util import Entries, ResultData, RawResult
 
 use_keyfile = False
 
-async def run(
+async def run_results(
   entries: Entries, max_concurrency: int = 20,
-) -> Dict[str, str]:
+) -> ResultData:
   task_sem = asyncio.Semaphore(max_concurrency)
   result_q: asyncio.Queue[RawResult] = asyncio.Queue()
   keyfile = os.environ.get('KEYFILE')
@@ -48,6 +48,12 @@ async def run(
   runner_coro = core.run_tasks(futures)
 
   results, _has_failures = await main.run(result_coro, runner_coro)
+  return results
+
+async def run(
+  entries: Entries, max_concurrency: int = 20,
+) -> Dict[str, str]:
+  results = await run_results(entries, max_concurrency)
   return {k: r.version for k, r in results.items()}
 
 @pytest_asyncio.fixture(scope="session")
@@ -56,6 +62,15 @@ async def get_version():
     entries = {name: config}
     newvers = await run(entries)
     return newvers.get(name)
+
+  return __call__
+
+@pytest_asyncio.fixture(scope="session")
+async def get_result():
+  async def __call__(name, config):
+    entries = {name: config}
+    results = await run_results(entries)
+    return results.get(name)
 
   return __call__
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -121,3 +121,63 @@ async def test_github_latest_tag(get_version):
         "use_latest_tag": True,
     }) == "release3"
 
+async def test_github_latest_tag_revision_creation_time(get_result):
+    result = await get_result("example", {
+        "source": "github",
+        "github": "harry-sanabria/ReleaseTestRepo",
+        "use_latest_tag": True,
+    })
+
+    assert result.version == "release3"
+    assert result.gitref == "refs/tags/release3"
+    assert result.revision == "2b3cdf6134b07ae6ac77f11b586dc1ae6d1521db"
+    assert result.creation_time is None
+    assert result.revision_creation_time == "2014-01-22T01:21:01Z"
+
+async def test_github_revision_creation_time(get_result):
+    result = await get_result("example", {
+        "source": "github",
+        "github": "harry-sanabria/ReleaseTestRepo",
+    })
+
+    assert result.version == "20140122.012101"
+    assert result.revision is not None
+    assert result.creation_time is None
+    assert result.revision_creation_time == "2014-01-22T01:21:01Z"
+
+async def test_github_latest_release_creation_time(get_result):
+    result = await get_result("example", {
+        "source": "github",
+        "github": "dpeukert/ReleaseTestRepo",
+        "use_latest_release": True,
+    })
+
+    assert result.version == "v0.0.0"
+    assert result.creation_time == "2023-08-25T21:05:58Z"
+    assert result.revision_creation_time is None
+
+async def test_github_latest_release_include_prereleases_timestamps(
+    get_result,
+):
+    result = await get_result("example", {
+        "source": "github",
+        "github": "dpeukert/ReleaseTestRepo",
+        "use_latest_release": True,
+        "include_prereleases": True,
+    })
+
+    assert result.version == "v0.0.1-pre"
+    assert result.creation_time == "2023-08-25T21:06:44Z"
+    assert result.revision == "626bc187f3ee2d44d1931754bf8e3a55070c3526"
+    assert result.revision_creation_time == "2023-08-25T21:06:20Z"
+
+async def test_github_max_release_creation_time(get_result):
+    result = await get_result("example", {
+        "source": "github",
+        "github": "harry-sanabria/ReleaseTestRepo",
+        "use_max_release": True,
+    })
+
+    assert result.version == "second_release"
+    assert result.creation_time == "2014-01-21T19:29:56Z"
+    assert result.revision_creation_time is None


### PR DESCRIPTION
Populate `creation_time` and `revision_creation_time` for the GitHub source using metadata already available from its existing API responses.

No additional requests are introduced, and version selection behavior is unchanged.

## GitHub timestamp mapping

| Retrieval mode | Version comes from | Revision | `creation_time` | `revision_creation_time` |
| --- | --- | --- | --- | --- |
| Default | Latest commit | Latest commit | — | Commit date |
| `use_latest_release` | Latest release | — | Release publication time | — |
| `use_max_release` | Maximum selected release | — | Release publication time | — |
| `use_latest_release` + `include_prereleases` | Latest release, including prereleases | Release tag commit | Release publication time | Tag commit date |
| `use_latest_tag` | Latest tag | Direct tag target object | — | Commit date or annotated tagger date |
| `use_max_tag` | Maximum selected tag | Direct tag target object | — | — |

For `use_latest_tag`, the existing meaning of `revision` is preserved:

- lightweight tags keep the directly targeted commit OID and use its `committedDate`;
- annotated tags keep the directly targeted tag-object OID and use `tagger.date`;
- annotated tags are not peeled to their underlying commit.

The implementation preserves GitHub timestamp strings as returned, without parsing or normalization.

Tests verify the exact timestamps and revision identifiers returned by the dedicated GitHub test repositories.