### PR TITLE
PyPI: populate `RichResult` timestamp metadata

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -618,6 +618,14 @@ use_pre_release
 
 This source supports :ref:`list options`.
 
+RichResult metadata:
+
+================  ===================================  ==========================
+Mode              ``creation_time``                    ``revision_creation_time``
+================  ===================================  ==========================
+all versions      earliest available file upload time  -
+================  ===================================  ==========================
+
 .. note::
    An additional dependency "packaging" is required.
    You can use ``pip install 'nvchecker[pypi]'``.

--- a/nvchecker_source/pypi.py
+++ b/nvchecker_source/pypi.py
@@ -34,9 +34,19 @@ async def get_version(name, conf, *, cache, **kwargs):
     if not use_pre_release and parsed_version.is_prerelease:
       continue
 
+    creation_time = min(
+      (
+        release_file['upload_time_iso_8601']
+        for release_file in vers
+        if release_file.get('upload_time_iso_8601') is not None
+      ),
+      default = None,
+    )
+
     ret.append(RichResult(
       version = version,
       url = f'https://pypi.org/project/{package}/{version}/',
+      creation_time = creation_time,
     ))
 
   return ret

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -1,39 +1,189 @@
 # MIT licensed
 # Copyright (c) 2013-2020 lilydjwg <lilydjwg@gmail.com>, et al.
 
-import pytest
-pytestmark = [pytest.mark.asyncio, pytest.mark.needs_net]
+from unittest.mock import AsyncMock
 
+import pytest
+
+from nvchecker_source import pypi
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.needs_net
 async def test_pypi(get_version):
     assert await get_version("example", {
         "source": "pypi",
     }) == "0.1.0"
 
+
+@pytest.mark.needs_net
 async def test_pypi_release(get_version):
     assert await get_version("example-test-package", {
         "source": "pypi",
         "pypi": "example-test-package",
     }) == "1.0.0"
 
+
+@pytest.mark.needs_net
 async def test_pypi_pre_release(get_version):
     assert await get_version("example-test-package", {
         "source": "pypi",
         "use_pre_release": 1,
     }) == "1.0.1a1"
 
+
+@pytest.mark.needs_net
 async def test_pypi_list(get_version):
     assert await get_version("urllib3", {
         "source": "pypi",
         "include_regex": "^1\\..*",
     }) == "1.26.20"
 
+
+@pytest.mark.needs_net
 async def test_pypi_invalid_version(get_version):
     await get_version("sympy", {
         "source": "pypi",
     })
 
+
+@pytest.mark.needs_net
 async def test_pypi_yanked_version(get_version):
     assert await get_version("urllib3", {
         "source": "pypi",
         "include_regex": "^(1\\..*)|(2\\.0\\.[0,1])",
     }) == "1.26.20"
+
+
+async def test_pypi_creation_time():
+    cache = AsyncMock()
+    cache.get_json.return_value = {
+        "releases": {
+            "1.0.0": [
+                {
+                    "yanked": False,
+                    "upload_time_iso_8601":
+                        "2024-01-02T03:04:05.000000Z",
+                },
+            ],
+        },
+    }
+
+    results = await pypi.get_version(
+        "example",
+        {"source": "pypi"},
+        cache=cache,
+    )
+
+    assert len(results) == 1
+
+    result = results[0]
+    assert result.version == "1.0.0"
+    assert result.url == "https://pypi.org/project/example/1.0.0/"
+    assert result.gitref is None
+    assert result.revision is None
+    assert (
+        result.creation_time
+        == "2024-01-02T03:04:05.000000Z"
+    )
+    assert result.revision_creation_time is None
+
+    cache.get_json.assert_awaited_once_with(
+        "https://pypi.org/pypi/example/json",
+    )
+
+
+async def test_pypi_creation_time_uses_earliest_file():
+    cache = AsyncMock()
+    cache.get_json.return_value = {
+        "releases": {
+            "1.0.0": [
+                {
+                    "yanked": False,
+                    "upload_time_iso_8601":
+                        "2024-01-02T03:04:09.000000Z",
+                },
+                {
+                    "yanked": False,
+                    "upload_time_iso_8601":
+                        "2024-01-02T03:04:05.000000Z",
+                },
+                {
+                    "yanked": False,
+                    "upload_time_iso_8601":
+                        "2024-01-02T03:04:07.000000Z",
+                },
+            ],
+        },
+    }
+
+    results = await pypi.get_version(
+        "example",
+        {"source": "pypi"},
+        cache=cache,
+    )
+
+    assert len(results) == 1
+    assert (
+        results[0].creation_time
+        == "2024-01-02T03:04:05.000000Z"
+    )
+
+
+async def test_pypi_creation_time_ignores_missing_timestamps():
+    cache = AsyncMock()
+    cache.get_json.return_value = {
+        "releases": {
+            "1.0.0": [
+                {
+                    "yanked": False,
+                },
+                {
+                    "yanked": False,
+                    "upload_time_iso_8601":
+                        "2024-01-02T03:04:05.000000Z",
+                },
+            ],
+        },
+    }
+
+    results = await pypi.get_version(
+        "example",
+        {"source": "pypi"},
+        cache=cache,
+    )
+
+    assert len(results) == 1
+    assert (
+        results[0].creation_time
+        == "2024-01-02T03:04:05.000000Z"
+    )
+
+
+@pytest.mark.parametrize("release_files", [
+    [],
+    [
+        {
+            "yanked": False,
+        },
+    ],
+])
+async def test_pypi_creation_time_unavailable(release_files):
+    cache = AsyncMock()
+    cache.get_json.return_value = {
+        "releases": {
+            "1.0.0": release_files,
+        },
+    }
+
+    results = await pypi.get_version(
+        "example",
+        {"source": "pypi"},
+        cache=cache,
+    )
+
+    assert len(results) == 1
+    assert results[0].version == "1.0.0"
+    assert results[0].creation_time is None
+    assert results[0].revision_creation_time is None


### PR DESCRIPTION
Populate `RichResult.creation_time` for PyPI releases using metadata already available in the existing PyPI JSON response.

A PyPI version may contain multiple distribution files, each with its own `upload_time_iso_8601`. This change uses the earliest available file upload timestamp as the release creation time.

No additional HTTP requests are introduced.

| PyPI object | `creation_time` | `revision_creation_time` |
|---|---|---|
| Release/version | Earliest available `upload_time_iso_8601` among its distribution files | `None` |

The implementation preserves the current behavior for:

- yanked releases
- prerelease filtering
- invalid versions
- empty historical releases
- list options and final version selection

If a release has no files, or none of its files provides `upload_time_iso_8601`, `creation_time` remains `None`.

Tests cover:

- a normal single-file release
- releases with multiple files
- selection of the earliest timestamp independent of file ordering
- files with missing timestamps
- releases without an available timestamp
- existing live PyPI version-selection behavior

The PyPI documentation now includes the corresponding `RichResult` metadata table.