### PR TITLE
Gitea: fix tag pagination

### DIFF
--- a/nvchecker_source/gitea.py
+++ b/nvchecker_source/gitea.py
@@ -46,7 +46,22 @@ async def get_version(
   if token:
     headers["Authorization"] = f'token {token}'
 
-  data = await cache.get_json(url, headers = headers)
+  if use_max_tag:
+    data = []
+    page = 1
+    while True:
+      page_data = await cache.get_json(
+        f'{url}?page={page}',
+        headers = headers,
+      )
+      if not page_data:
+        break
+
+      data.extend(page_data)
+      page += 1
+  else:
+    data = await cache.get_json(url, headers = headers)
+
   if use_max_tag:
     return [
       RichResult(

--- a/tests/test_gitea.py
+++ b/tests/test_gitea.py
@@ -2,9 +2,11 @@
 # Copyright (c) 2013-2020 lilydjwg <lilydjwg@gmail.com>, et al.
 
 import pytest
-pytestmark = [pytest.mark.asyncio,
-              pytest.mark.needs_net]
 
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.needs_net
 @pytest.mark.flaky(reruns=10)
 async def test_gitea(get_version):
     ver = await get_version("example", {
@@ -13,6 +15,8 @@ async def test_gitea(get_version):
     assert ver.startswith('20')
     assert 'T' in ver
 
+
+@pytest.mark.needs_net
 @pytest.mark.flaky(reruns=10)
 async def test_gitea_max_tag_with_include(get_version):
     assert await get_version("example", {
@@ -22,6 +26,8 @@ async def test_gitea_max_tag_with_include(get_version):
         "include_regex": r'v0\.9.*',
     }) == "v0.9.2"
 
+
+@pytest.mark.needs_net
 async def test_gitea_latest_release(get_version):
     ver = await get_version("example", {
         "source": "gitea",
@@ -31,3 +37,69 @@ async def test_gitea_latest_release(get_version):
     })
     assert ver.startswith('v3.'), ver
 
+
+async def test_gitea_max_tag_fetches_all_pages():
+    from nvchecker_source import gitea
+
+    class FakeCache:
+        def __init__(self):
+            self.urls = []
+
+        async def get_json(self, url, *, headers):
+            assert headers == {}
+            self.urls.append(url)
+
+            responses = {
+                "https://gitea.example/api/v1/repos/owner/repo/tags?page=1": [
+                    {
+                        "name": "v2.0.0",
+                        "id": "revision-2",
+                    },
+                ],
+                "https://gitea.example/api/v1/repos/owner/repo/tags?page=2": [
+                    {
+                        "name": "v1.0.0",
+                        "id": "revision-1",
+                    },
+                ],
+                "https://gitea.example/api/v1/repos/owner/repo/tags?page=3": [],
+            }
+            return responses[url]
+
+    class FakeKeyManager:
+        def get_key(self, host, key):
+            assert host == "gitea.example"
+            assert key == "gitea_gitea.example"
+            return None
+
+    cache = FakeCache()
+
+    result = await gitea.get_version(
+        "example",
+        {
+            "source": "gitea",
+            "host": "gitea.example",
+            "gitea": "owner/repo",
+            "use_max_tag": True,
+        },
+        cache=cache,
+        keymanager=FakeKeyManager(),
+    )
+
+    assert [tag.version for tag in result] == [
+        "v2.0.0",
+        "v1.0.0",
+    ]
+    assert [tag.revision for tag in result] == [
+        "revision-2",
+        "revision-1",
+    ]
+    assert [tag.url for tag in result] == [
+        "https://gitea.example/owner/repo/releases/tag/v2.0.0",
+        "https://gitea.example/owner/repo/releases/tag/v1.0.0",
+    ]
+    assert cache.urls == [
+        "https://gitea.example/api/v1/repos/owner/repo/tags?page=1",
+        "https://gitea.example/api/v1/repos/owner/repo/tags?page=2",
+        "https://gitea.example/api/v1/repos/owner/repo/tags?page=3",
+    ]


### PR DESCRIPTION
Close #345 

Fetch all pages from the Gitea tags endpoint when `use_max_tag` is enabled.

The Gitea tags endpoint is paginated, but the source previously treated the first response page as the complete tag list. This caused older tags to be ignored.

## Problem

The existing integration test for `gitea/tea` uses:

```toml
use_max_tag = true
include_regex = 'v0\.9.*'
```

and expects `v0.9.2`.

The repository still contains the `v0.9.*` tags, but the live Gitea API currently returns only 10 of its 27 tags on the first page. The matching tags are on page 2, so nvchecker reported:

```text
include_regex matched no versions
```

The existing CI did not expose the failure because its mitmproxy cache replayed an older response for the unpaginated tags URL.

Manual checks against the live Gitea API return:

| Configuration | Result |
|---|---|
| `use_max_tag = true`, `include_regex = 'v0\.9.*'` | `v0.9.2` |
| `use_max_tag = true` | `v0.15.1` |