### PR TITLE
GitLab: populate `RichResult` timestamp metadata

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -622,6 +622,20 @@ To set an authorization token, you can set:
 
 This source supports :ref:`list options` when ``use_max_tag`` is set.
 
+RichResult metadata
+~~~~~~~~~~~~~~~~~~~
+
+When available from the existing GitLab API responses, this source populates
+the following optional ``RichResult`` fields. No additional API requests are
+issued solely to retrieve timestamp information.
+
+================  ======================  ==========================
+Mode              ``creation_time``       ``revision_creation_time``
+================  ======================  ==========================
+default commit    -                       commit timestamp
+``use_max_tag``   tag creation time       commit timestamp
+================  ======================  ==========================
+
 Check PyPI
 ~~~~~~~~~~
 ::

--- a/nvchecker_source/gitlab.py
+++ b/nvchecker_source/gitlab.py
@@ -55,6 +55,8 @@ async def get_version_real(
         gitref = f"refs/tags/{tag['name']}",
         revision = tag['commit']['id'],
         url = f'https://{host}/{conf["gitlab"]}/-/tags/{tag["name"]}',
+        creation_time = tag.get('created_at'),
+        revision_creation_time = tag['commit'].get('created_at'),
       ) for tag in data
     ]
   else:
@@ -62,6 +64,7 @@ async def get_version_real(
       version = data[0]['created_at'].split('T', 1)[0].replace('-', ''),
       revision = data[0]['id'],
       url = data[0]['web_url'],
+      revision_creation_time = data[0]['created_at'],
     )
 
 def check_ratelimit(exc, name):

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -44,3 +44,35 @@ async def test_gitlab_max_tag_with_ignored(get_version):
         "ignored": "v1.1.0 v1.1.1",
     }) == "v1.0.0"
 
+async def test_gitlab_revision_creation_time(get_result):
+    result = await get_result("example", {
+        "source": "gitlab",
+        "gitlab": "gitlab-org/gitlab-test",
+    })
+
+    assert result.version == "20190625"
+    assert result.revision is not None
+    assert result.creation_time is None
+    assert (
+        result.revision_creation_time
+        == "2019-06-25T23:59:19.000+00:00"
+    )
+
+async def test_gitlab_max_tag_timestamps(get_result):
+    result = await get_result("example", {
+        "source": "gitlab",
+        "gitlab": "gitlab-org/gitlab-test",
+        "use_max_tag": True,
+    })
+
+    assert result.version == "v1.1.1"
+    assert result.gitref == "refs/tags/v1.1.1"
+    assert (
+        result.revision
+        == "189a6c924013fc3fe40d6f1ec1dc20214183bc97"
+    )
+    assert result.creation_time == "2019-11-20T14:56:20.000Z"
+    assert (
+        result.revision_creation_time
+        == "2019-10-11T18:06:49.000+02:00"
+    )


### PR DESCRIPTION
Populate the optional `RichResult` timestamp fields for the GitLab source using metadata already available in its existing API responses.

No additional API requests are introduced.

## Behavior

| Mode | `creation_time` | `revision_creation_time` |
|---|---|---|
| Default commit | - | Selected commit timestamp |
| `use_max_tag` | Selected tag creation timestamp, when available | Referenced commit timestamp |

In default mode, the returned version remains a date derived from the selected commit. Following the existing field semantics, `revision_creation_time` is populated for the commit referenced by `revision`, while `creation_time` remains unset.

In `use_max_tag` mode:

- `creation_time` comes from the selected tag object;
- `revision_creation_time` comes from the nested commit referenced by the existing `revision` field.

The existing version-selection and revision semantics are unchanged.
