### PR TITLE
Add a RichResult.changelog_url field

### DIFF
--- a/nvchecker/core.py
+++ b/nvchecker/core.py
@@ -421,6 +421,7 @@ def check_version_update(
       revision = r.revision,
       old_version = oldver,
       url = r.url,
+      changelog_url = r.changelog_url,
       rich_result = _rich_result_to_dict(r),
     )
   else:

--- a/nvchecker/core.py
+++ b/nvchecker/core.py
@@ -421,7 +421,6 @@ def check_version_update(
       revision = r.revision,
       old_version = oldver,
       url = r.url,
-      changelog_url = r.changelog_url,
       rich_result = _rich_result_to_dict(r),
     )
   else:

--- a/nvchecker/slogconf.py
+++ b/nvchecker/slogconf.py
@@ -26,8 +26,9 @@ def _console_msg(event):
   else:
     msg = evt
 
-  if 'revision' in event and not event['revision']:
-      del event['revision']
+  for optional_field in ['revision', 'changelog_url']:
+      if optional_field in event and not event[optional_field]:
+          del event[optional_field]
 
   if 'name' in event:
     msg = f"{event['name']}: {msg}"

--- a/nvchecker/slogconf.py
+++ b/nvchecker/slogconf.py
@@ -26,9 +26,8 @@ def _console_msg(event):
   else:
     msg = evt
 
-  for optional_field in ['revision', 'changelog_url']:
-      if optional_field in event and not event[optional_field]:
-          del event[optional_field]
+  if 'revision' in event and not event['revision']:
+      del event['revision']
 
   if 'name' in event:
     msg = f"{event['name']}: {msg}"
@@ -36,7 +35,10 @@ def _console_msg(event):
 
   event['msg'] = msg
 
-  if 'rich_result' in event:
+  if rich_result := event.get('rich_result'):
+    if changelog_url := rich_result.get('changelog_url'):
+        event['changelog_url'] = changelog_url
+
     del event['rich_result']
 
   return event

--- a/nvchecker/util.py
+++ b/nvchecker/util.py
@@ -52,6 +52,7 @@ if sys.version_info[:2] >= (3, 10):
     gitref: Optional[str] = None
     revision: Optional[str] = None
     url: Optional[str] = None
+    changelog_url: Optional[str] = None
     # Creation/publication time of the selected version object, if applicable.
     creation_time: Optional[str] = None
     # Creation time of the underlying revision object, if applicable.
@@ -66,6 +67,7 @@ else:
     gitref: Optional[str] = None
     revision: Optional[str] = None
     url: Optional[str] = None
+    changelog_url: Optional[str] = None
     # Creation/publication time of the selected version object, if applicable.
     creation_time: Optional[str] = None
     # Creation time of the underlying revision object, if applicable.

--- a/nvchecker_source/apt.py
+++ b/nvchecker_source/apt.py
@@ -184,6 +184,7 @@ async def get_version(
     return RichResult(
       version = version,
       url = changelog,
+      changelog_url = changelog,
     )
   else:
     return version

--- a/nvchecker_source/pypi.py
+++ b/nvchecker_source/pypi.py
@@ -43,10 +43,17 @@ async def get_version(name, conf, *, cache, **kwargs):
       default = None,
     )
 
+    urls = data['info']['project_urls']
+    changelog_url = next(
+        (value for key, value in urls.items() if key.lower().startswith(('change', 'release'))),
+        None
+    )
+
     ret.append(RichResult(
       version = version,
       url = f'https://pypi.org/project/{package}/{version}/',
       creation_time = creation_time,
+      changelog_url = changelog_url,
     ))
 
   return ret

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -56,9 +56,28 @@ async def test_pypi_yanked_version(get_version):
     }) == "1.26.20"
 
 
+@pytest.mark.needs_net
+async def test_pypi_changelog(get_result):
+    result = await get_result("example", {
+        "source": "pypi",
+    })
+
+    assert result.changelog_url == None
+
+
+@pytest.mark.needs_net
+async def test_pypi_no_changelog(get_result):
+    result = await get_result("numpy", {
+        "source": "pypi",
+    })
+
+    assert result.changelog_url.startswith('https://numpy.org')
+
+
 async def test_pypi_creation_time():
     cache = AsyncMock()
     cache.get_json.return_value = {
+        "info": {"project_urls": {}},
         "releases": {
             "1.0.0": [
                 {
@@ -97,6 +116,7 @@ async def test_pypi_creation_time():
 async def test_pypi_creation_time_uses_earliest_file():
     cache = AsyncMock()
     cache.get_json.return_value = {
+        "info": {"project_urls": {}},
         "releases": {
             "1.0.0": [
                 {
@@ -134,6 +154,7 @@ async def test_pypi_creation_time_uses_earliest_file():
 async def test_pypi_creation_time_ignores_missing_timestamps():
     cache = AsyncMock()
     cache.get_json.return_value = {
+        "info": {"project_urls": {}},
         "releases": {
             "1.0.0": [
                 {
@@ -172,6 +193,7 @@ async def test_pypi_creation_time_ignores_missing_timestamps():
 async def test_pypi_creation_time_unavailable(release_files):
     cache = AsyncMock()
     cache.get_json.return_value = {
+        "info": {"project_urls": {}},
         "releases": {
             "1.0.0": release_files,
         },


### PR DESCRIPTION
Hello,

Consider this pull request a feature discussion with an implementation example.

Motivation: When I see a package update, I find it useful to have the changelog readily available. Most packages I track are on PyPI, where many project have changelog URLs as part of their metadata.

So, I added a `changelog_url` field to the `RichResult` structure to track these URLs. 

I also saw that APT packages have a changelog URL available, although it matches the usual URL, so its utility there is questionable.