### PR TITLE
nvcmp: honour the per-entry sort_version_key

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -236,11 +236,16 @@ exclude_regex
 
 sort_version_key
   Sort the version string using this key function. Choose among
-  ``parse_version``, ``vercmp``, ``awesomeversion`` and ``portage``. Default value is
-  ``parse_version``. ``parse_version`` uses an old version of
+  ``parse_version``, ``vercmp``, ``awesomeversion``, ``portage`` and ``none``.
+  Default value is ``parse_version``. ``parse_version`` uses an old version of
   ``pkg_resources.parse_version``. ``vercmp`` uses ``pyalpm.vercmp``.
   ``awesomeversion`` uses `awesomeversion <https://github.com/ludeeus/awesomeversion>`_.
-  ``portage`` uses ``portage.versions.vercmp``.
+  ``portage`` uses ``portage.versions.vercmp``. ``none`` does not order the
+  versions; use it where they carry no ordering, such as the commit hash from a
+  ``git`` source with ``use_commit``. If the source returns several versions,
+  ``none`` takes the last one and logs a warning.
+
+  ``nvcmp`` also reads this option, in preference to its own ``--sort``.
 
 ignored
   Version strings that are explicitly ignored, separated by whitespace. This

--- a/nvchecker/core.py
+++ b/nvchecker/core.py
@@ -355,8 +355,12 @@ def apply_list_options(
   if not versions:
     return None
 
-  sort_version_key = sort_version_keys[
-    conf.get("sort_version_key", "parse_version")]
+  sort_version_key_name = conf.get("sort_version_key", "parse_version")
+  if sort_version_key_name == "none" and len(versions) > 1:
+    logger.warning('sort_version_key is none and the source returned several '
+                   'versions; using the last one',
+                   name=name, versions=versions)
+  sort_version_key = sort_version_keys[sort_version_key_name]
   versions.sort(key=lambda version: sort_version_key(str(version)))
 
   return versions[-1]

--- a/nvchecker/sortversion.py
+++ b/nvchecker/sortversion.py
@@ -38,7 +38,11 @@ except ImportError:
     raise NotImplementedError("Using portage but portage can not be imported!")
   portage_available = False
 
+def no_sort(k: str) -> int:
+  return 0
+
 sort_version_keys = {
+  "none": no_sort,
   "parse_version": parse_version,
   "vercmp": vercmp,
   "awesomeversion": AwesomeVersion,

--- a/nvchecker/tools.py
+++ b/nvchecker/tools.py
@@ -152,7 +152,9 @@ def cmp() -> None:
 
         if older:
           if args.newer:
-            continue  # don't store this diff
+            logger.debug('not newer, skipped', name=name,
+                         oldver=oldver, newver=newver)
+            continue
           diff['delta'] = 'old'
         else:
           diff['delta'] = 'new'
@@ -162,7 +164,8 @@ def cmp() -> None:
 
     elif newver is None:
       if args.newer:
-        continue  # don't store this diff
+        logger.debug('gone, skipped', name=name, oldver=oldver)
+        continue
       diff['delta'] = 'gone'
 
     if args.all or diff['delta'] != 'equal':

--- a/nvchecker/tools.py
+++ b/nvchecker/tools.py
@@ -87,17 +87,19 @@ def cmp() -> None:
   parser.add_argument('-s', '--sort',
                       choices=('parse_version', 'vercmp', 'awesomeversion', 'portage', 'none'),
                       default='parse_version',
-                      help='Version compare method to backwards the arrow '
+                      help='Version compare method to backwards the arrow, '
+                           'for entries without sort_version_key '
                            '(default: parse_version)')
   parser.add_argument('-n', '--newer', action='store_true',
-                      help='Shows only the newer ones according to --sort.')
+                      help='Shows only the newer ones, according to the '
+                           "entry's sort_version_key or --sort.")
   parser.add_argument('--exit-status', action='store_true',
                       help="exit with status 4 if there are updates")
   args = parser.parse_args()
   if core.process_common_arguments(args):
     return
 
-  opt = core.load_file(args.file, use_keymanager=False)[1]
+  entries, opt = core.load_file(args.file, use_keymanager=False)
   if opt.ver_files is None:
     logger.critical(
       "doesn't have 'oldver' and 'newver' set.",
@@ -110,6 +112,18 @@ def cmp() -> None:
 
   oldvers = {k: v.version for k, v in core.read_verfile(oldverf).items()}
   newvers = {k: v.version for k, v in core.read_verfile(newverf).items()}
+
+  from .sortversion import sort_version_keys
+  entry_sort = {}  # takes precedence over --sort
+  for name, conf in entries.items():
+    key = conf.get('sort_version_key')
+    if key is None:
+      continue
+    if key not in sort_version_keys:
+      logger.critical('unknown sort_version_key.', name=name,
+                      sort_version_key=key, choices=list(sort_version_keys))
+      sys.exit(2)
+    entry_sort[name] = key
 
   differences = []
 
@@ -126,14 +140,17 @@ def cmp() -> None:
       if oldver == newver:
         diff['delta'] = 'equal'
 
-      elif args.sort == "none":
-        diff['delta'] = 'new'  # assume it's a new version if we're not comparing
-
       else:
-        from .sortversion import sort_version_keys
-        version = sort_version_keys[args.sort]
+        sort_name = entry_sort.get(name, args.sort)
+        version = sort_version_keys[sort_name]
 
-        if version(oldver) > version(newver):
+        try:
+          older = version(oldver) > version(newver)
+        except NotImplementedError as e:
+          logger.critical(str(e), name=name, sort_version_key=sort_name)
+          sys.exit(2)
+
+        if older:
           if args.newer:
             continue  # don't store this diff
           diff['delta'] = 'old'

--- a/tests/test_nvcmp.py
+++ b/tests/test_nvcmp.py
@@ -1,0 +1,71 @@
+import json
+import logging
+import sys
+
+import pytest
+import structlog
+
+from nvchecker import core, sortversion
+
+def write(tmp_path, conf, old, new):
+  (tmp_path / 'c.toml').write_text(
+    '[__config__]\noldver="old.json"\nnewver="new.json"\n' + conf)
+  (tmp_path / 'old.json').write_text(old)
+  (tmp_path / 'new.json').write_text(new)
+  return str(tmp_path / 'c.toml')
+
+@pytest.fixture
+def run(tmp_path, monkeypatch, capsys):
+  # process_common_arguments adds a root log handler per call, and structlog's
+  # logger writes to stdout, where nvcmp -j puts its JSON.
+  monkeypatch.setattr(core, 'process_common_arguments', lambda args: False)
+  saved = structlog.get_config()
+  structlog.configure(
+    wrapper_class=structlog.make_filtering_bound_logger(logging.CRITICAL))
+
+  def go(conf, old, new, *argv):
+    path = write(tmp_path, conf, old, new)
+    monkeypatch.setattr(sys, 'argv', ['nvcmp', '-c', path, *argv])
+    from nvchecker.tools import cmp
+    cmp()
+    return capsys.readouterr().out
+  yield go
+
+  structlog.configure(**saved)
+
+def test_per_entry_key_beats_sort(run):
+  # these two hashes are ordered backwards by parse_version; swap them and the
+  # test passes without the fix
+  out = run(
+    '[a]\nsource="manual"\nmanual="1"\nsort_version_key="none"\n'
+    '[b]\nsource="manual"\nmanual="1"\n',
+    '{"version":2,"data":{"a":{"version":"094fdb"},"b":{"version":"2.0"}}}',
+    '{"version":2,"data":{"a":{"version":"decd9b"},"b":{"version":"1.0"}}}',
+    '-n', '-j', '-q')
+  assert json.loads(out) == ['a']
+
+def test_sort_none_applies_without_per_entry_key(run):
+  out = run(
+    '[a]\nsource="manual"\nmanual="1"\n',
+    '{"version":2,"data":{"a":{"version":"2.0"}}}',
+    '{"version":2,"data":{"a":{"version":"1.0"}}}',
+    '-s', 'none', '-j')
+  assert json.loads(out)[0]['delta'] == 'new'
+
+def test_unknown_key_exits(run):
+  with pytest.raises(SystemExit) as e:
+    run('[a]\nsource="manual"\nmanual="1"\nsort_version_key="bogus"\n',
+        '{"version":2,"data":{"a":{"version":"1.0"}}}',
+        '{"version":2,"data":{"a":{"version":"2.0"}}}')
+  assert e.value.code == 2
+
+def test_unavailable_comparator_exits(run, monkeypatch):
+  # an absent library leaves a stub in the dict that raises when called
+  def stub(v):
+    raise NotImplementedError('stub')
+  monkeypatch.setitem(sortversion.sort_version_keys, 'awesomeversion', stub)
+  with pytest.raises(SystemExit) as e:
+    run('[a]\nsource="manual"\nmanual="1"\nsort_version_key="awesomeversion"\n',
+        '{"version":2,"data":{"a":{"version":"1.0"}}}',
+        '{"version":2,"data":{"a":{"version":"2.0"}}}')
+  assert e.value.code == 2


### PR DESCRIPTION
`nvcmp` compares every entry with the global `--sort`, so a config that mixes
entries whose versions are ordered with entries whose versions are not gets the
wrong answer for one of the two groups.

A `git` source with `use_commit` reports a commit hash. Two hashes carry no
ancestry between them: the parent pointer lives inside the commit object, not in
the hash string, and `ls-remote` returns neither. Comparing them with
`parse_version` therefore answers a question the inputs cannot answer. It is
not plain string order either: the legacy key zero-pads digit runs and prefixes
alpha runs with `*`, which sorts below any digit, so a hash starting with a
digit outranks one starting with a letter.

```
094fdba5ca7566efd98e1c36fb2295ef508c145a -> decd9b705eb81626f694335b8d5940538beb06da   old
decd9b705eb81626f694335b8d5940538beb06da -> 094fdba5ca7566efd98e1c36fb2295ef508c145a   new
```

Both are ordinary forward moves. Under `--newer` the first is dropped, with
nothing logged. A ref can also move backward after a force push, so even "the
ref changed" does not imply "moved ahead".

Reproducer, two entries in the same situation:

```toml
[__config__]
oldver = "old.json"
newver = "new.json"

[pkg-a]
source = "manual"
manual = "1"

[pkg-b]
source = "manual"
manual = "1"
```

```json
old.json  {"version":2,"data":{"pkg-a":{"version":"094fdba5ca7566efd98e1c36fb2295ef508c145a"},
                               "pkg-b":{"version":"decd9b705eb81626f694335b8d5940538beb06da"}}}
new.json  {"version":2,"data":{"pkg-a":{"version":"decd9b705eb81626f694335b8d5940538beb06da"},
                               "pkg-b":{"version":"094fdba5ca7566efd98e1c36fb2295ef508c145a"}}}
```

```
$ nvcmp -c c.toml -n
pkg-b decd9b705eb81626f694335b8d5940538beb06da -> 094fdba5ca7566efd98e1c36fb2295ef508c145a
```

`pkg-a` is gone.

## Change

An entry can already say how its versions compare, through `sort_version_key`,
and `apply_list_options` honours it when picking the newest of a list. `nvcmp`
read only `--sort`. It now reads the per-entry option first and falls back to
`--sort`.

`none` becomes a valid `sort_version_key` so an entry can declare that its
versions carry no ordering:

```toml
[mosh-git]
source = "git"
git = "https://github.com/mobile-shell/mosh.git"
use_commit = true
sort_version_key = "none"
```

With that, `nvcmp --newer` keeps the entry when the commit changes and still
drops genuine downgrades elsewhere in the same file.

## Compatibility

An entry that does not set `sort_version_key` behaves exactly as before.

Two things do change for entries that set it.

The per-entry value takes precedence over `--sort`, so `nvcmp --sort none` no
longer forces every entry; it is the default for entries that stay quiet.

Bad values now exit 2 instead of producing a traceback. `nvchecker` reads
`sort_version_key` only inside the list branch of `_process_result`, so a
non-list source, which is exactly the `git use_commit` case, silently accepted
anything before. Two kinds reach the comparison: a name that is not a key at
all, and a name whose library is missing, since `vercmp`, `awesomeversion` and
`portage` are always present in `sort_version_keys` as stubs that raise
`NotImplementedError` when called. The second was already reachable through
`--sort` before this change.

## Tests

`tests/test_nvcmp.py` is new. `nvcmp` had no coverage at all before; nothing
under `tests/` imported `nvchecker.tools`.

Three of the four fail on master and pass with the change: the per-entry
override, an unknown key, and a comparator whose library is missing. The fourth,
`test_sort_none_applies_without_per_entry_key`, passes on both by design.
Removing the `elif args.sort == "none"` branch moved global `--sort none` onto
the new `no_sort` entry, so it guards behaviour the change must preserve.

The missing-library case is exercised by putting a raising stub in
`sort_version_keys` rather than by skipping when `awesomeversion` is absent,
since it would then skip wherever CI installs it.

The rest of the suite is unchanged against master. The failures I see are
`test_pagure`, `test_ubuntupkg` and sometimes `test_snapcraft` needing network,
and `test_alpm` needing a pacman database.
